### PR TITLE
[Update] Version1.1.0

### DIFF
--- a/ReceiptManager/ReceiptManager.xcodeproj/project.pbxproj
+++ b/ReceiptManager/ReceiptManager.xcodeproj/project.pbxproj
@@ -690,7 +690,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.PakHyo.ReceiptManager;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -728,7 +728,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.PakHyo.ReceiptManager;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/ReceiptManager/ReceiptManager.xcodeproj/project.pbxproj
+++ b/ReceiptManager/ReceiptManager.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		3CB4CF3E2A13486600E9CBAB /* DateFormatter+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB4CF3D2A13486600E9CBAB /* DateFormatter+Extension.swift */; };
 		3CB4CF402A13768900E9CBAB /* UIStackView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB4CF3F2A13768900E9CBAB /* UIStackView+Extension.swift */; };
 		3CB4CF422A13D78000E9CBAB /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB4CF412A13D78000E9CBAB /* UIImage+Extension.swift */; };
+		3CB563F92A286D22008A6CD0 /* OCRTextExtractable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB563F82A286D22008A6CD0 /* OCRTextExtractable.swift */; };
+		3CB563FB2A287C39008A6CD0 /* OCRResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB563FA2A287C39008A6CD0 /* OCRResult.swift */; };
 		3CC893B72A0CC06900055872 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC893B62A0CC06900055872 /* UILabel+Extension.swift */; };
 		3CC893B92A0CC07400055872 /* UITextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC893B82A0CC07400055872 /* UITextField+Extension.swift */; };
 		3CC893BB2A0CCCDB00055872 /* ImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC893BA2A0CCCDB00055872 /* ImageCell.swift */; };
@@ -96,6 +98,8 @@
 		3CB4CF3D2A13486600E9CBAB /* DateFormatter+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extension.swift"; sourceTree = "<group>"; };
 		3CB4CF3F2A13768900E9CBAB /* UIStackView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Extension.swift"; sourceTree = "<group>"; };
 		3CB4CF412A13D78000E9CBAB /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
+		3CB563F82A286D22008A6CD0 /* OCRTextExtractable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRTextExtractable.swift; sourceTree = "<group>"; };
+		3CB563FA2A287C39008A6CD0 /* OCRResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRResult.swift; sourceTree = "<group>"; };
 		3CC893B62A0CC06900055872 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		3CC893B82A0CC07400055872 /* UITextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
 		3CC893BA2A0CCCDB00055872 /* ImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCell.swift; sourceTree = "<group>"; };
@@ -159,6 +163,7 @@
 		3C9AA3432A0117B60014807B /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				3CB563F72A286CFD008A6CD0 /* OCR */,
 				3C56C65D2A0963960058869C /* Protocol */,
 				3C9AA3442A0117C10014807B /* Extension */,
 				3C56C6592A08EAFE0058869C /* ConstantColor.swift */,
@@ -228,6 +233,15 @@
 				3CAF8AF12A162444002251DD /* LargeImageViewController.swift */,
 			);
 			path = DetailScene;
+			sourceTree = "<group>";
+		};
+		3CB563F72A286CFD008A6CD0 /* OCR */ = {
+			isa = PBXGroup;
+			children = (
+				3CB563F82A286D22008A6CD0 /* OCRTextExtractable.swift */,
+				3CB563FA2A287C39008A6CD0 /* OCRResult.swift */,
+			);
+			path = OCR;
 			sourceTree = "<group>";
 		};
 		3CDCDC4729FC002D00C2BEF6 /* Source */ = {
@@ -470,6 +484,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3CDCDC5529FC050B00C2BEF6 /* CoreDataStorage.swift in Sources */,
+				3CB563F92A286D22008A6CD0 /* OCRTextExtractable.swift in Sources */,
 				3C9AA34B2A012EDA0014807B /* Transition.swift in Sources */,
 				3CC893B72A0CC06900055872 /* UILabel+Extension.swift in Sources */,
 				3CDCDC4E29FC00C700C2BEF6 /* Receipt.swift in Sources */,
@@ -497,6 +512,7 @@
 				3C56C65F2A0963A50058869C /* CellReuseIdentifiable.swift in Sources */,
 				3CB4CF422A13D78000E9CBAB /* UIImage+Extension.swift in Sources */,
 				3C9AA3592A0130310014807B /* ComposeViewController.swift in Sources */,
+				3CB563FB2A287C39008A6CD0 /* OCRResult.swift in Sources */,
 				3CDCDC5029FC02B300C2BEF6 /* PayType.swift in Sources */,
 				3C2E18D829FBCC5F00E8E9C6 /* SceneDelegate.swift in Sources */,
 				3C9AA35F2A0130620014807B /* ComposeViewModel.swift in Sources */,
@@ -665,6 +681,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -702,6 +719,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ReceiptManager/ReceiptManager.xcodeproj/project.pbxproj
+++ b/ReceiptManager/ReceiptManager.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3C2E18E229FBCC6100E8E9C6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3C2E18E129FBCC6100E8E9C6 /* Assets.xcassets */; };
 		3C2E18E529FBCC6100E8E9C6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3C2E18E329FBCC6100E8E9C6 /* LaunchScreen.storyboard */; };
 		3C3E95652A14BAB80020A0FE /* NumberFormatter+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3E95642A14BAB80020A0FE /* NumberFormatter+Extension.swift */; };
+		3C485BBF2A28912D007F7229 /* ComposeInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C485BBE2A28912D007F7229 /* ComposeInformationView.swift */; };
 		3C56C65A2A08EAFE0058869C /* ConstantColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C56C6592A08EAFE0058869C /* ConstantColor.swift */; };
 		3C56C65C2A08ECED0058869C /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C56C65B2A08ECED0058869C /* ListTableViewCell.swift */; };
 		3C56C65F2A0963A50058869C /* CellReuseIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C56C65E2A0963A50058869C /* CellReuseIdentifiable.swift */; };
@@ -70,6 +71,7 @@
 		3C2E18E429FBCC6100E8E9C6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		3C2E18E629FBCC6100E8E9C6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3C3E95642A14BAB80020A0FE /* NumberFormatter+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Extension.swift"; sourceTree = "<group>"; };
+		3C485BBE2A28912D007F7229 /* ComposeInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeInformationView.swift; sourceTree = "<group>"; };
 		3C56C6592A08EAFE0058869C /* ConstantColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantColor.swift; sourceTree = "<group>"; };
 		3C56C65B2A08ECED0058869C /* ListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableViewCell.swift; sourceTree = "<group>"; };
 		3C56C65E2A0963A50058869C /* CellReuseIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellReuseIdentifiable.swift; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 				3CC893BA2A0CCCDB00055872 /* ImageCell.swift */,
 				3C86FB872A1B407A000CC99B /* SelectImageViewController.swift */,
 				3C86FB8B2A1B90ED000CC99B /* ImagePickerCell.swift */,
+				3C485BBE2A28912D007F7229 /* ComposeInformationView.swift */,
 			);
 			path = ComposeScene;
 			sourceTree = "<group>";
@@ -520,6 +523,7 @@
 				3CC893B92A0CC07400055872 /* UITextField+Extension.swift in Sources */,
 				3C9AA3612A01306C0014807B /* DetailViewModel.swift in Sources */,
 				3C3E95652A14BAB80020A0FE /* NumberFormatter+Extension.swift in Sources */,
+				3C485BBF2A28912D007F7229 /* ComposeInformationView.swift in Sources */,
 				3C9AA35B2A0130490014807B /* ListViewModel.swift in Sources */,
 				3CAF8AF42A1627BA002251DD /* LargeImageViewModel.swift in Sources */,
 				3C56C65C2A08ECED0058869C /* ListTableViewCell.swift in Sources */,

--- a/ReceiptManager/ReceiptManager.xcodeproj/project.pbxproj
+++ b/ReceiptManager/ReceiptManager.xcodeproj/project.pbxproj
@@ -685,7 +685,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -723,7 +723,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ReceiptManager/ReceiptManager/Source/Utility/OCR/OCRResult.swift
+++ b/ReceiptManager/ReceiptManager/Source/Utility/OCR/OCRResult.swift
@@ -1,0 +1,15 @@
+//
+//  OCRResult.swift
+//  ReceiptManager
+//
+//  Created by parkhyo on 2023/06/01.
+//
+
+import Foundation
+
+struct OCRResult {
+    var date: Date = Date()
+    var store: String = ""
+    var price: Int = .zero
+    var paymentType: Int = PayType.cash.rawValue
+}

--- a/ReceiptManager/ReceiptManager/Source/Utility/OCR/OCRTextExtractable.swift
+++ b/ReceiptManager/ReceiptManager/Source/Utility/OCR/OCRTextExtractable.swift
@@ -60,7 +60,7 @@ final class OCRTextExtractor: OCRTextExtractable {
         var filterResult = OCRResult()
         
         // 상호명 Default
-        filterResult.store = result[0]
+        filterResult.store = result.first ?? ""
         
         for index in 0..<result.count {
             let text = result[index]

--- a/ReceiptManager/ReceiptManager/Source/Utility/OCR/OCRTextExtractable.swift
+++ b/ReceiptManager/ReceiptManager/Source/Utility/OCR/OCRTextExtractable.swift
@@ -1,0 +1,136 @@
+//
+//  OCRTextExtractable.swift
+//  ReceiptManager
+//
+//  Created by parkhyo on 2023/06/01.
+//
+
+import Foundation
+import Vision
+import VisionKit
+
+protocol OCRTextExtractable {
+    func extractText(data: Data, completion: @escaping (OCRResult) -> Void)
+}
+
+final class OCRTextExtractor: OCRTextExtractable {
+    func extractText(data: Data, completion: @escaping (OCRResult) -> Void) {
+        guard let image = UIImage(data: data)?.cgImage else { return }
+        
+        let handler = VNImageRequestHandler(cgImage: image, options: [:])
+        
+        let request = VNRecognizeTextRequest { [weak self] request, error in
+            guard let self = self else { return }
+            
+            guard let observations = request.results as? [VNRecognizedTextObservation], error == nil else {
+                return
+            }
+            
+            let ocrText = observations.compactMap { text in
+                text.topCandidates(1).first?.string.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            
+            let filterResult = self.filterOCR(ocrText)
+            
+            DispatchQueue.main.async {
+                completion(filterResult)
+            }
+        }
+        
+        if #available(iOS 16.0, *) {
+            request.revision = VNRecognizeTextRequestRevision3
+            request.recognitionLanguages =  ["ko-KR"]
+        } else {
+            request.revision = VNRecognizeTextRequestRevision2
+            request.recognitionLanguages =  ["en-US"]
+        }
+        
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+        
+        do {
+            try handler.perform([request])
+        } catch {
+            print(error)
+        }
+    }
+    
+    private func filterOCR(_ result: [String]) -> OCRResult {
+        var ocrResult = OCRResult()
+        
+        // 상호명 Default
+        ocrResult.store = result[0]
+        
+        for index in 0..<result.count {
+            let text = result[index]
+            
+            // 상호명 추출
+            if text == "상호명" && index + 1 < result.count {
+                ocrResult.store = result[index + 1]
+                continue
+            }
+            
+            if let dateExtract = extractDate(from: text) {
+                ocrResult.date = dateExtract
+            }
+            
+            if let priceExtract = extractPrice(from: text) {
+                ocrResult.price = priceExtract
+            }
+            
+            if let payTypeExtract = extractPayType(from: text) {
+                ocrResult.paymentType = payTypeExtract
+            }
+        }
+        
+        return ocrResult
+    }
+    
+    // 날짜 추출
+    private func extractDate(from text: String) -> Date? {
+        let dateFormats = [
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy/MM/dd HH:mm:ss",
+            "yy-MM-dd HH:mm:ss",
+            "yy/MM/dd HH:mm:ss",
+            "yyyy-MM-dd"
+        ]
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "ko_KR") // 날짜 형식의 로케일 설정
+        
+        for format in dateFormats {
+            dateFormatter.dateFormat = format
+            if let date = dateFormatter.date(from: text) {
+                return date
+            }
+        }
+        
+        return nil
+    }
+    
+    // 가격 추출
+    private func extractPrice(from text: String) -> Int? {
+        if text.contains("원") || text.contains(".") || text.contains(",") {
+            let priceText = text.replacingOccurrences(of: "원", with: "")
+                .replacingOccurrences(of: ",", with: "")
+                .replacingOccurrences(of: ".", with: "")
+                .replacingOccurrences(of: " ", with: "")
+            
+            guard let price = Int(priceText) else { return nil }
+            return price
+        }
+        
+        return nil
+    }
+    
+    private func extractPayType(from text: String) -> Int? {
+        if text.contains(PayType.cash.description) {
+            return PayType.cash.rawValue
+        } else if text.contains(PayType.card.description) {
+            return PayType.card.rawValue
+        }
+        
+        return nil
+    }
+}

--- a/ReceiptManager/ReceiptManager/Source/View/ComposeScene/ComposeInformationView.swift
+++ b/ReceiptManager/ReceiptManager/Source/View/ComposeScene/ComposeInformationView.swift
@@ -121,11 +121,11 @@ extension ComposeInformationView {
         datePicker.clipsToBounds = true
         datePicker.layer.cornerRadius = 10
         datePicker.backgroundColor = ConstantColor.registerColor
-        datePicker.subviews[.zero].subviews[.zero].subviews[.zero].alpha = .zero
         datePicker.addTarget(self, action: #selector(datePickerWheel), for: .valueChanged)
     }
 }
 
+// MARK: - UI Constraint
 extension ComposeInformationView {
     private func setupView() {
         backgroundColor = ConstantColor.backGrouncColor

--- a/ReceiptManager/ReceiptManager/Source/View/ComposeScene/ComposeInformationView.swift
+++ b/ReceiptManager/ReceiptManager/Source/View/ComposeScene/ComposeInformationView.swift
@@ -1,0 +1,170 @@
+//
+//  ComposeInformationView.swift
+//  ReceiptManager
+//
+//  Created by parkhyo on 2023/06/01.
+//
+
+import UIKit
+
+final class ComposeInformationView: UIView {
+    let datePicker = UIDatePicker()
+    private let dateLabel = UILabel(text: ConstantText.date, font: .preferredFont(forTextStyle: .body))
+    private let storeLabel = UILabel(text: ConstantText.store, font: .preferredFont(forTextStyle: .body))
+    private let productLabel = UILabel(text: ConstantText.product, font: .preferredFont(forTextStyle: .body))
+    private let priceLabel = UILabel(text: ConstantText.price, font: .preferredFont(forTextStyle: .body))
+    
+    let storeTextField = UITextField(
+        textColor: .white,
+        placeholder: ConstantText.input,
+        tintColor: ConstantColor.registerColor,
+        backgroundColor: ConstantColor.cellColor
+    )
+    
+    let productNameTextField = UITextField(
+        textColor: .white,
+        placeholder: ConstantText.input,
+        tintColor: ConstantColor.registerColor,
+        backgroundColor: ConstantColor.cellColor
+    )
+    
+    let priceTextField = UITextField(
+        textColor: .white,
+        placeholder: ConstantText.input,
+        tintColor: ConstantColor.registerColor,
+        backgroundColor: ConstantColor.cellColor
+    )
+    
+    private lazy var storeStackView = UIStackView(
+        subViews: [storeLabel, storeTextField],
+        axis: .horizontal,
+        alignment: .fill,
+        distribution: .fill,
+        spacing: 10
+    )
+    
+    private lazy var productStackView = UIStackView(
+        subViews: [productLabel, productNameTextField],
+        axis: .horizontal,
+        alignment: .fill,
+        distribution: .fill,
+        spacing: 10
+    )
+    
+    private lazy var priceStackView = UIStackView(
+        subViews: [priceLabel, priceTextField, payTypeSegmented],
+        axis: .horizontal,
+        alignment: .fill,
+        distribution: .fill,
+        spacing: 10
+    )
+    
+    private lazy var mainStackView = UIStackView(
+        subViews: [storeStackView, productStackView, priceStackView],
+        axis: .vertical,
+        alignment: .fill,
+        distribution: .fill,
+        spacing: 20
+    )
+    
+    let payTypeSegmented: UISegmentedControl = {
+        let segment = UISegmentedControl(items: [ConstantText.cash, ConstantText.card])
+        segment.selectedSegmentIndex = .zero
+        segment.setTitleTextAttributes([.foregroundColor: UIColor.black], for: .selected)
+        segment.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .normal)
+        segment.selectedSegmentTintColor = ConstantColor.registerColor
+        
+        return segment
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+        setupDatePicker()
+        setupConstraints()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UITextField Delegate
+extension ComposeInformationView: UITextFieldDelegate {
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        if textField == priceTextField {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+
+            if let input = textField.text?.replacingOccurrences(of: ",", with: "") {
+                if let number = formatter.number(from: input) {
+                    textField.text = formatter.string(from: number)
+                } else {
+                    textField.text = ""
+                }
+            }
+        }
+    }
+}
+
+// MARK: - DatePicker
+extension ComposeInformationView {
+    @objc private func datePickerWheel(_ sender: UIDatePicker) -> Date? {
+        return sender.date
+    }
+    
+    private func setupDatePicker() {
+        datePicker.tintColor = .black
+        datePicker.datePickerMode = .date
+        datePicker.preferredDatePickerStyle = .compact
+        datePicker.locale = Locale(identifier: "ko-kr")
+        datePicker.clipsToBounds = true
+        datePicker.layer.cornerRadius = 10
+        datePicker.backgroundColor = ConstantColor.registerColor
+        datePicker.subviews[.zero].subviews[.zero].subviews[.zero].alpha = .zero
+        datePicker.addTarget(self, action: #selector(datePickerWheel), for: .valueChanged)
+    }
+}
+
+extension ComposeInformationView {
+    private func setupView() {
+        backgroundColor = ConstantColor.backGrouncColor
+        priceTextField.keyboardType = .numberPad
+        
+        [datePicker, mainStackView].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        [dateLabel, datePicker, mainStackView].forEach(addSubview(_:))
+        
+        [storeTextField, productNameTextField, priceTextField].forEach {
+            $0.setPlaceholder(color: .lightGray)
+            $0.delegate  = self
+            $0.borderStyle = .roundedRect
+        }
+    }
+    
+    private func setupConstraints() {
+        let safeArea = safeAreaLayoutGuide
+        
+        NSLayoutConstraint.activate([
+            dateLabel.widthAnchor.constraint(equalTo: safeArea.widthAnchor, multiplier: 0.15),
+            priceLabel.widthAnchor.constraint(equalTo: safeArea.widthAnchor, multiplier: 0.15),
+            storeLabel.widthAnchor.constraint(equalTo: safeArea.widthAnchor, multiplier: 0.15),
+            productLabel.widthAnchor.constraint(equalTo: safeArea.widthAnchor, multiplier: 0.15),
+            
+            dateLabel.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: 20),
+            dateLabel.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 20),
+            datePicker.centerYAnchor.constraint(equalTo: dateLabel.centerYAnchor),
+            datePicker.leadingAnchor.constraint(equalTo: dateLabel.trailingAnchor, constant: 10),
+            
+            mainStackView.topAnchor.constraint(equalTo: dateLabel.bottomAnchor, constant: 20),
+            mainStackView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 20),
+            mainStackView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -20)
+        ])
+        
+        priceTextField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        payTypeSegmented.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        payTypeSegmented.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    }
+}

--- a/ReceiptManager/ReceiptManager/Source/View/ComposeScene/ComposeViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/View/ComposeScene/ComposeViewController.swift
@@ -124,12 +124,9 @@ final class ComposeViewController: UIViewController, ViewModelBindable {
         
         viewModel.memoRelay
             .asDriver(onErrorJustReturn: "")
-            .map { [weak self] text in
-                if text != "" {
-                    self?.placeHoderLabel.isHidden = true
-                }
-                return text
-            }
+            .do(onNext: { [weak self] text in
+                self?.placeHoderLabel.isHidden = !text.isEmpty
+            })
             .drive(memoTextView.rx.text)
             .disposed(by: rx.disposeBag)
         

--- a/ReceiptManager/ReceiptManager/Source/View/ComposeScene/ComposeViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/View/ComposeScene/ComposeViewController.swift
@@ -21,78 +21,11 @@ final class ComposeViewController: UIViewController, ViewModelBindable {
     }
 
     var viewModel: ComposeViewModel?
-    private let datePicker = UIDatePicker()
     
+    private let informationView = ComposeInformationView()
     private let placeHoderLabel = UILabel(text: ConstantText.memo, font: .preferredFont(forTextStyle: .body))
     
-    private let dateLabel = UILabel(text: ConstantText.date, font: .preferredFont(forTextStyle: .body))
-    private let storeLabel = UILabel(text: ConstantText.store, font: .preferredFont(forTextStyle: .body))
-    private let productLabel = UILabel(text: ConstantText.product, font: .preferredFont(forTextStyle: .body))
-    private let priceLabel = UILabel(text: ConstantText.price, font: .preferredFont(forTextStyle: .body))
     private let countLabel = UILabel(text: "", font: .preferredFont(forTextStyle: .body))
-    
-    private let storeTextField = UITextField(
-        textColor: .white,
-        placeholder: ConstantText.input,
-        tintColor: ConstantColor.registerColor,
-        backgroundColor: ConstantColor.cellColor
-    )
-    
-    private let productNameTextField = UITextField(
-        textColor: .white,
-        placeholder: ConstantText.input,
-        tintColor: ConstantColor.registerColor,
-        backgroundColor: ConstantColor.cellColor
-    )
-    
-    private let priceTextField = UITextField(
-        textColor: .white,
-        placeholder: ConstantText.input,
-        tintColor: ConstantColor.registerColor,
-        backgroundColor: ConstantColor.cellColor
-    )
-    
-    private lazy var storeStackView = UIStackView(
-        subViews: [storeLabel, storeTextField],
-        axis: .horizontal,
-        alignment: .fill,
-        distribution: .fill,
-        spacing: 10
-    )
-    
-    private lazy var productStackView = UIStackView(
-        subViews: [productLabel, productNameTextField],
-        axis: .horizontal,
-        alignment: .fill,
-        distribution: .fill,
-        spacing: 10
-    )
-    
-    private lazy var priceStackView = UIStackView(
-        subViews: [priceLabel, priceTextField, payTypeSegmented],
-        axis: .horizontal,
-        alignment: .fill,
-        distribution: .fill,
-        spacing: 10
-    )
-    
-    private lazy var mainStackView = UIStackView(
-        subViews: [storeStackView, productStackView, priceStackView],
-        axis: .vertical,
-        alignment: .fill,
-        distribution: .fill,
-        spacing: 20
-    )
-    
-    private let payTypeSegmented: UISegmentedControl = {
-        let segment = UISegmentedControl(items: [ConstantText.cash, ConstantText.card])
-        segment.selectedSegmentIndex = .zero
-        segment.setTitleTextAttributes([.foregroundColor: UIColor.black], for: .selected)
-        segment.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .normal)
-        segment.selectedSegmentTintColor = ConstantColor.registerColor
-        
-        return segment
-    }()
     
     private let collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
@@ -127,7 +60,6 @@ final class ComposeViewController: UIViewController, ViewModelBindable {
         setupFirstCell()
         setupNotification()
         setupNavigationBar()
-        setupDatePicker()
         setupConstraints()
         createKeyboardDownButton()
     }
@@ -163,17 +95,17 @@ final class ComposeViewController: UIViewController, ViewModelBindable {
         
         viewModel.dateRelay
             .asDriver(onErrorJustReturn: Date())
-            .drive(datePicker.rx.date)
+            .drive(informationView.datePicker.rx.date)
             .disposed(by: rx.disposeBag)
         
         viewModel.storeRelay
             .asDriver(onErrorJustReturn: "")
-            .drive(storeTextField.rx.text)
+            .drive(informationView.storeTextField.rx.text)
             .disposed(by: rx.disposeBag)
         
         viewModel.productRelay
             .asDriver(onErrorJustReturn: "")
-            .drive(productNameTextField.rx.text)
+            .drive(informationView.productNameTextField.rx.text)
             .disposed(by: rx.disposeBag)
         
         viewModel.priceRelay
@@ -182,12 +114,12 @@ final class ComposeViewController: UIViewController, ViewModelBindable {
                 let priceText = NumberFormatter.numberDecimal(from: price)
                 return priceText == "0" ? "" : priceText
             }
-            .drive(priceTextField.rx.text)
+            .drive(informationView.priceTextField.rx.text)
             .disposed(by: rx.disposeBag)
         
         viewModel.payRelay
             .asDriver(onErrorJustReturn: .zero)
-            .drive(payTypeSegmented.rx.selectedSegmentIndex)
+            .drive(informationView.payTypeSegmented.rx.selectedSegmentIndex)
             .disposed(by: rx.disposeBag)
         
         viewModel.memoRelay
@@ -217,26 +149,26 @@ final class ComposeViewController: UIViewController, ViewModelBindable {
                 cell.delegate = self
                 cell.setupReceiptImage(data)
             }
-            .disposed(by: rx.disposeBag)            
+            .disposed(by: rx.disposeBag)
     }
     
     private func bindUItoViewModel() {
         guard let viewModel = viewModel else { return }
         
         // UI의 Data를 ViewModel에 바인딩
-        datePicker.rx.date
+        informationView.datePicker.rx.date
             .bind(to: viewModel.dateRelay)
             .disposed(by: rx.disposeBag)
         
-        storeTextField.rx.text.orEmpty
+        informationView.storeTextField.rx.text.orEmpty
             .bind(to: viewModel.storeRelay)
             .disposed(by: rx.disposeBag)
         
-        productNameTextField.rx.text.orEmpty
+        informationView.productNameTextField.rx.text.orEmpty
             .bind(to: viewModel.productRelay)
             .disposed(by: rx.disposeBag)
         
-        priceTextField.rx.text.orEmpty
+        informationView.priceTextField.rx.text.orEmpty
             .map { price in
                 let input = price.replacingOccurrences(of: ",", with: "")
                 return Int(input) ?? .zero
@@ -244,7 +176,7 @@ final class ComposeViewController: UIViewController, ViewModelBindable {
             .bind(to: viewModel.priceRelay)
             .disposed(by: rx.disposeBag)
             
-        payTypeSegmented.rx.selectedSegmentIndex
+        informationView.payTypeSegmented.rx.selectedSegmentIndex
             .bind(to: viewModel.payRelay)
             .disposed(by: rx.disposeBag)
         
@@ -271,25 +203,6 @@ extension ComposeViewController {
     
     @objc private func tapSaveButton() {
         viewModel?.saveAction()
-    }
-}
-
-// MARK: - DatePicker
-extension ComposeViewController {
-    @objc private func datePickerWheel(_ sender: UIDatePicker) -> Date? {
-        return sender.date
-    }
-    
-    private func setupDatePicker() {
-        datePicker.tintColor = .black
-        datePicker.datePickerMode = .date
-        datePicker.preferredDatePickerStyle = .compact
-        datePicker.locale = Locale(identifier: "ko-kr")
-        datePicker.clipsToBounds = true
-        datePicker.layer.cornerRadius = 10
-        datePicker.backgroundColor = ConstantColor.registerColor
-        datePicker.subviews[.zero].subviews[.zero].subviews[.zero].alpha = .zero
-        datePicker.addTarget(self, action: #selector(datePickerWheel), for: .valueChanged)
     }
 }
 
@@ -470,23 +383,8 @@ extension ComposeViewController {
     }
 }
 
-// MARK: - TextField, TextViewDelagate
-extension ComposeViewController: UITextFieldDelegate, UITextViewDelegate {
-    func textFieldDidChangeSelection(_ textField: UITextField) {
-        if textField == priceTextField {
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .decimal
-            
-            if let input = textField.text?.replacingOccurrences(of: ",", with: "") {
-                if let number = formatter.number(from: input) {
-                    textField.text = formatter.string(from: number)
-                } else {
-                    textField.text = ""
-                }
-            }
-        }
-    }
-    
+// MARK: - TextViewDelagate
+extension ComposeViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         placeHoderLabel.isHidden = true
     }
@@ -604,20 +502,13 @@ extension ComposeViewController {
     private func setupView() {
         view.backgroundColor = ConstantColor.backGrouncColor
         
-        [datePicker, mainStackView, memoTextView, collectionView].forEach {
+        [informationView, memoTextView, collectionView].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
         
-        [dateLabel, datePicker, mainStackView, countLabel, collectionView, memoTextView, placeHoderLabel]
+        [informationView, countLabel, collectionView, memoTextView, placeHoderLabel]
             .forEach(view.addSubview(_:))
-        
-        [storeTextField, productNameTextField, priceTextField].forEach {
-            $0.setPlaceholder(color: .lightGray)
-            $0.delegate = self
-            $0.borderStyle = .roundedRect
-        }
-        
-        priceTextField.keyboardType = .numberPad
+
         placeHoderLabel.textColor = .lightGray
         memoTextView.delegate = self
     }
@@ -626,21 +517,12 @@ extension ComposeViewController {
         let safeArea = view.safeAreaLayoutGuide
         
         NSLayoutConstraint.activate([
-            dateLabel.widthAnchor.constraint(equalTo: safeArea.widthAnchor, multiplier: 0.15),
-            priceLabel.widthAnchor.constraint(equalTo: safeArea.widthAnchor, multiplier: 0.15),
-            storeLabel.widthAnchor.constraint(equalTo: safeArea.widthAnchor, multiplier: 0.15),
-            productLabel.widthAnchor.constraint(equalTo: safeArea.widthAnchor, multiplier: 0.15),
+            informationView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            informationView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+            informationView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+            informationView.heightAnchor.constraint(equalToConstant: 200),
             
-            dateLabel.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: 20),
-            dateLabel.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 20),
-            datePicker.centerYAnchor.constraint(equalTo: dateLabel.centerYAnchor),
-            datePicker.leadingAnchor.constraint(equalTo: dateLabel.trailingAnchor, constant: 10),
-            
-            mainStackView.topAnchor.constraint(equalTo: dateLabel.bottomAnchor, constant: 20),
-            mainStackView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 20),
-            mainStackView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -20),
-            
-            countLabel.topAnchor.constraint(equalTo: mainStackView.bottomAnchor, constant: 20),
+            countLabel.topAnchor.constraint(equalTo: informationView.bottomAnchor, constant: 20),
             countLabel.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 20),
             countLabel.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -20),
             
@@ -658,9 +540,5 @@ extension ComposeViewController {
             placeHoderLabel.leadingAnchor.constraint(equalTo: memoTextView.leadingAnchor, constant: 5),
             placeHoderLabel.trailingAnchor.constraint(equalTo: memoTextView.trailingAnchor)
         ])
-        
-        priceTextField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        payTypeSegmented.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-        payTypeSegmented.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     }
 }

--- a/ReceiptManager/ReceiptManager/Source/ViewModel/ComposeViewModel.swift
+++ b/ReceiptManager/ReceiptManager/Source/ViewModel/ComposeViewModel.swift
@@ -48,7 +48,20 @@ final class ComposeViewModel: CommonViewModel {
         
         super.init(title: title, sceneCoordinator: sceneCoordinator, storage: storage)
     }
+    
+    private func bindOCRExtractor() {
+        ocrExtractor.ocrResult
+            .bind { [weak self] ocrResult in
+                self?.dateRelay.accept(ocrResult.date)
+                self?.storeRelay.accept(ocrResult.store)
+                self?.priceRelay.accept(ocrResult.price)
+                self?.payRelay.accept(ocrResult.paymentType)
+            }
+            .disposed(by: disposeBag)
+    }
+}
 
+extension ComposeViewModel {
     func updateReceiptData(_ data: Data?, isFirstReceipt: Bool) {
         guard let data = data else { return }
         
@@ -59,13 +72,8 @@ final class ComposeViewModel: CommonViewModel {
         } else {
             // 첫번째 이미지 OCR 로직 동작
             if currentReceiptData.count == 1 {
-                ocrExtractor.extractText(data: data) { [weak self] filterResult in
-                    print(filterResult.date)
-                    self?.dateRelay.accept(filterResult.date)
-                    self?.storeRelay.accept(filterResult.store)
-                    self?.priceRelay.accept(filterResult.price)
-                    self?.payRelay.accept(filterResult.paymentType)
-                }
+                bindOCRExtractor()
+                ocrExtractor.extractText(data: data)
             }
             
             currentReceiptData.append(data)

--- a/ReceiptManager/ReceiptManager/Source/ViewModel/DetailViewModel.swift
+++ b/ReceiptManager/ReceiptManager/Source/ViewModel/DetailViewModel.swift
@@ -43,7 +43,8 @@ final class DetailViewModel: CommonViewModel {
             sceneCoordinator: sceneCoordinator,
             storage: storage,
             receipt: receipt,
-            delegate: self
+            delegate: self,
+            ocrExtractor: OCRTextExtractor()
         )
         
         let composeScene = Scene.compose(composeViewModel)

--- a/ReceiptManager/ReceiptManager/Source/ViewModel/ListViewModel.swift
+++ b/ReceiptManager/ReceiptManager/Source/ViewModel/ListViewModel.swift
@@ -79,7 +79,8 @@ final class ListViewModel: CommonViewModel {
         let composeViewModel = ComposeViewModel(
             title: ConstantText.register,
             sceneCoordinator: sceneCoordinator,
-            storage: storage
+            storage: storage,
+            ocrExtractor: OCRTextExtractor()
         )
         
         let composeScene = Scene.compose(composeViewModel)

--- a/ReceiptManager/ReceiptManager/Source/ViewModel/MainViewModel.swift
+++ b/ReceiptManager/ReceiptManager/Source/ViewModel/MainViewModel.swift
@@ -45,7 +45,8 @@ final class MainViewModel: CommonViewModel {
         let composeViewModel = ComposeViewModel(
             title: ConstantText.register,
             sceneCoordinator: sceneCoordinator,
-            storage: storage
+            storage: storage,
+            ocrExtractor: OCRTextExtractor()
         )
         
         let composeScene = Scene.compose(composeViewModel)


### PR DESCRIPTION
오류 수정 및 개선
- iOS 14.0에서 Compose View에서 Date Picker 텍스트 보이지 않는 오류 수정.
    - 원인 : DatePicker의 SubView의 alpha 값을 투명으로 했었는데 문제가 되어서 삭제

기능 추가
- OCR 기능 구현
    - 등록한 첫번째 이미지에 대해서 OCR 기능이 제공되도록 구현
    - OCR은 날짜, 상호명, 가격, 현금/카드 타입 구분에 활용.
    - Vision Kit 사용하였으며 한글 지원이 iOS 16부터이므로 그 아래 버전은 정확도가 많이 떨어진다.
