### PR TITLE
[Version/2.0.1] Repository Pattern, CoreData Async

### DIFF
--- a/ReceiptManager/ReceiptManager.xcodeproj/project.pbxproj
+++ b/ReceiptManager/ReceiptManager.xcodeproj/project.pbxproj
@@ -94,6 +94,10 @@
 		3CC893B72A0CC06900055872 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC893B62A0CC06900055872 /* UILabel+Extension.swift */; };
 		3CC893B92A0CC07400055872 /* UITextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC893B82A0CC07400055872 /* UITextField+Extension.swift */; };
 		3CC893BB2A0CCCDB00055872 /* ImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC893BA2A0CCCDB00055872 /* ImageCell.swift */; };
+		3CC8DAD12B52BF6C00FE89B4 /* ExpenseRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC8DAD02B52BF6C00FE89B4 /* ExpenseRepository.swift */; };
+		3CC8DAD32B52C4A400FE89B4 /* OCRRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC8DAD22B52C4A400FE89B4 /* OCRRepository.swift */; };
+		3CC8DAD52B52C61800FE89B4 /* CurrencyRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC8DAD42B52C61800FE89B4 /* CurrencyRepository.swift */; };
+		3CC8DAD72B52C84100FE89B4 /* DateRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC8DAD62B52C84100FE89B4 /* DateRepository.swift */; };
 		3CD62AF52B12F71000D10E54 /* UserDefaultService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD62AF42B12F71000D10E54 /* UserDefaultService.swift */; };
 		3CD8B9322B065E4400968A7E /* DetailViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD8B9312B065E4400968A7E /* DetailViewReactor.swift */; };
 		3CD8B9352B0664FA00968A7E /* DetailViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD8B9342B0664FA00968A7E /* DetailViewCoordinator.swift */; };
@@ -228,6 +232,10 @@
 		3CC893B62A0CC06900055872 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		3CC893B82A0CC07400055872 /* UITextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
 		3CC893BA2A0CCCDB00055872 /* ImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCell.swift; sourceTree = "<group>"; };
+		3CC8DAD02B52BF6C00FE89B4 /* ExpenseRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseRepository.swift; sourceTree = "<group>"; };
+		3CC8DAD22B52C4A400FE89B4 /* OCRRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRRepository.swift; sourceTree = "<group>"; };
+		3CC8DAD42B52C61800FE89B4 /* CurrencyRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyRepository.swift; sourceTree = "<group>"; };
+		3CC8DAD62B52C84100FE89B4 /* DateRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRepository.swift; sourceTree = "<group>"; };
 		3CD62AF42B12F71000D10E54 /* UserDefaultService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultService.swift; sourceTree = "<group>"; };
 		3CD8B9312B065E4400968A7E /* DetailViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewReactor.swift; sourceTree = "<group>"; };
 		3CD8B9342B0664FA00968A7E /* DetailViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewCoordinator.swift; sourceTree = "<group>"; };
@@ -645,6 +653,17 @@
 			path = Reactor;
 			sourceTree = "<group>";
 		};
+		3CC8DACF2B52BE6800FE89B4 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				3CC8DAD02B52BF6C00FE89B4 /* ExpenseRepository.swift */,
+				3CC8DAD22B52C4A400FE89B4 /* OCRRepository.swift */,
+				3CC8DAD42B52C61800FE89B4 /* CurrencyRepository.swift */,
+				3CC8DAD62B52C84100FE89B4 /* DateRepository.swift */,
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
 		3CD8B9332B065E4900968A7E /* Reactor */ = {
 			isa = PBXGroup;
 			children = (
@@ -661,6 +680,7 @@
 				3C74A37E2B04CDFE00377A73 /* Coordinator */,
 				3CDCDC4A29FC007400C2BEF6 /* Scene */,
 				3CDCDC4C29FC00A300C2BEF6 /* Model */,
+				3CC8DACF2B52BE6800FE89B4 /* Repository */,
 				3CDCDC5129FC03C400C2BEF6 /* Service */,
 			);
 			path = Source;
@@ -1042,6 +1062,7 @@
 				3CA5366A2B0E085B00EA77AA /* LimitAlbumViewReactor.swift in Sources */,
 				3CAF8AF22A162444002251DD /* LargeImageViewController.swift in Sources */,
 				3C765AEB2B0F598600EB7A6C /* SettingViewCoordinator.swift in Sources */,
+				3CC8DAD12B52BF6C00FE89B4 /* ExpenseRepository.swift in Sources */,
 				3CFBF7FD2B282ED50010DC83 /* OCRResultView.swift in Sources */,
 				3C1B36902A3441D300749774 /* ConstantImage.swift in Sources */,
 				3C32F8FE2AE903A800A805AD /* MappingModelV1toV2.xcmappingmodel in Sources */,
@@ -1058,6 +1079,7 @@
 				3C9AA3502A012FC20014807B /* ListViewController.swift in Sources */,
 				3C3F55482B1CCE3C00A6EAB5 /* CalendarCellReactor.swift in Sources */,
 				3C9AA3572A01301F0014807B /* DetailViewController.swift in Sources */,
+				3CC8DAD52B52C61800FE89B4 /* CurrencyRepository.swift in Sources */,
 				3CA5366C2B0E0B2600EA77AA /* LimitAlbumViewCoordinator.swift in Sources */,
 				3C2E18D629FBCC5F00E8E9C6 /* AppDelegate.swift in Sources */,
 				3CA7223A2B051749005347AB /* ListViewReactor.swift in Sources */,
@@ -1113,8 +1135,10 @@
 				3C33883F2B051CFD00A9613B /* ListViewCoordinator.swift in Sources */,
 				3C78C8C92B21BBAD007FF68A /* AnalysisViewController.swift in Sources */,
 				3C9AA3482A012C880014807B /* ExpenseNavigationBar.swift in Sources */,
+				3CC8DAD32B52C4A400FE89B4 /* OCRRepository.swift in Sources */,
 				3CF5EB4C2B2575C100A524C5 /* PayTypeRatingView.swift in Sources */,
 				3C05E09D2B0C80F30062C3F7 /* ComposeViewCoordinator.swift in Sources */,
+				3CC8DAD72B52C84100FE89B4 /* DateRepository.swift in Sources */,
 				3CB4CF402A13768900E9CBAB /* UIStackView+Extension.swift in Sources */,
 				3C78C8CE2B21BFF0007FF68A /* AnalysisViewCoordinator.swift in Sources */,
 				3C852F052B185B0E00F48CD3 /* DateManageService.swift in Sources */,

--- a/ReceiptManager/ReceiptManager/Source/Application/SceneDelegate.swift
+++ b/ReceiptManager/ReceiptManager/Source/Application/SceneDelegate.swift
@@ -28,14 +28,19 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let storageService = DefaultStorageService(modelName: ConstantText.receiptManager)
             let userDefaultService = DefaultUserDefaultService()
             let dateManageService = DefaultDateManageService()
+            
+            let expenseRepository = DefaultExpenseRepository(service: storageService)
+            let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
+            let dateRepository = DefaultDateRepository(service: dateManageService)
+            
             storageService.sync()
             
             let mainTabBarCoordinator = MainTabBarCoordinator(
                 window: window,
                 mainNavigationController: UINavigationController(),
-                storageService: storageService,
-                userDefaultService: userDefaultService,
-                dateManageService: dateManageService
+                expenseRepository: expenseRepository,
+                currencyRepository: currencyRepository,
+                dateRepository: dateRepository
             )
             mainTabBarCoordinator.start()
         }

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/AnalysisViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/AnalysisViewCoordinator.swift
@@ -30,10 +30,14 @@ final class AnalysisViewCoordinator: Coordinator {
     }
     
     func start() {
+        let expenseRepository = DefaultExpenseRepository(service: storageService)
+        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
+        let dateRepository = DefaultDateRepository(service: DefaultDateManageService())
         let analysisViewReactor = AnalysisViewReactor(
-            storageService: storageService,
-            userDefaultService: userDefaultService,
-            dateService: DefaultDateManageService())
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository,
+            dateRepository: dateRepository
+        )
         let analysisViewController = AnalysisViewController(reactor: analysisViewReactor)
         
         analysisViewController.coordinator = self

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/AnalysisViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/AnalysisViewCoordinator.swift
@@ -14,24 +14,22 @@ final class AnalysisViewCoordinator: Coordinator {
     var mainNavigationController: UINavigationController?
     var subNavigationController: UINavigationController?
     
-    private let storageService: StorageService
-    private let userDefaultService: UserDefaultService
+    private let expenseRepository: ExpenseRepository
+    private let currencyRepository: CurrencyRepository
     
     init(
         mainNavigationController: UINavigationController?,
         subNavigationController: UINavigationController?,
-        storageService: StorageService,
-        userDefaultService: UserDefaultService
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository
     ) {
         self.mainNavigationController = mainNavigationController
         self.subNavigationController = subNavigationController
-        self.storageService = storageService
-        self.userDefaultService = userDefaultService
+        self.expenseRepository = expenseRepository
+        self.currencyRepository = currencyRepository
     }
     
     func start() {
-        let expenseRepository = DefaultExpenseRepository(service: storageService)
-        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
         let dateRepository = DefaultDateRepository(service: DefaultDateManageService())
         let analysisViewReactor = AnalysisViewReactor(
             expenseRepository: expenseRepository,

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/BookMarkViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/BookMarkViewCoordinator.swift
@@ -14,24 +14,22 @@ final class BookMarkViewCoordinator: Coordinator {
     var mainNavigationController: UINavigationController?
     var subNavigationController: UINavigationController?
     
-    private let storageService: StorageService
-    private let userDefaultService: UserDefaultService
+    private let expenseRepository: ExpenseRepository
+    private let currencyRepository: CurrencyRepository
     
     init(
         mainNavigationController: UINavigationController?,
         subNavigationController: UINavigationController,
-        storageService: StorageService,
-        userDefaultService: UserDefaultService
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository
     ) {
         self.mainNavigationController = mainNavigationController
         self.subNavigationController = subNavigationController
-        self.storageService = storageService
-        self.userDefaultService = userDefaultService
+        self.expenseRepository = expenseRepository
+        self.currencyRepository = currencyRepository
     }
     
     func start() {
-        let expenseRepository = DefaultExpenseRepository(service: storageService)
-        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
         let bookMarkViewReactor = BookMarkViewReactor(
             expenseRepository: expenseRepository, 
             currencyRepository: currencyRepository
@@ -47,8 +45,8 @@ extension BookMarkViewCoordinator {
     func presentDetailView(expense: Receipt) {
         let detailViewCoordinator = DetailViewCoordinator(
             mainNavigationController: mainNavigationController,
-            storageService: storageService,
-            userDefaultService: userDefaultService,
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository,
             expense: expense
         )
         

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/BookMarkViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/BookMarkViewCoordinator.swift
@@ -30,9 +30,11 @@ final class BookMarkViewCoordinator: Coordinator {
     }
     
     func start() {
+        let expenseRepository = DefaultExpenseRepository(service: storageService)
+        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
         let bookMarkViewReactor = BookMarkViewReactor(
-            storageService: storageService,
-            userDefaultService: userDefaultService
+            expenseRepository: expenseRepository, 
+            currencyRepository: currencyRepository
         )
         let bookMarkViewController = BookMarkViewController(reactor: bookMarkViewReactor)
         bookMarkViewController.coordinator = self

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/CalendarListViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/CalendarListViewCoordinator.swift
@@ -40,10 +40,14 @@ final class CalendarListViewCoordinator: Coordinator {
     }
     
     func start() {
+        let expenseRepository = DefaultExpenseRepository(service: storageService)
+        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
+        let dateRepository = DefaultDateRepository(service: dateManageService)
+        
         let calendarListViewReactor = CalendarListReactor(
-            storageService: storageService,
-            userDefaultService: userDefaultService,
-            dateManageService: dateManageService,
+            expenseRepository: expenseRepository,
+            dateRepository: dateRepository,
+            currencyRepository: currencyRepository,
             day: day,
             weekIndex: weekIndex
         )

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/CalendarListViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/CalendarListViewCoordinator.swift
@@ -14,25 +14,25 @@ final class CalendarListViewCoordinator: Coordinator {
     var mainNavigationController: UINavigationController?
     var subNavigationController: UINavigationController?
     
-    private let storageService: StorageService
-    private let userDefaultService: UserDefaultService
-    private let dateManageService: DateManageService
+    private let expenseRepository: ExpenseRepository
+    private let currencyRepository: CurrencyRepository
+    private let dateRepository: DateRepository
     
     private let day: String
     private let weekIndex: Int
     
     init(
         mainNavigationController: UINavigationController?,
-        storageService: StorageService,
-        userDefaultService: UserDefaultService,
-        dateManageService: DateManageService,
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository,
+        dateRepository: DateRepository,
         day: String,
         index: Int
     ) {
         self.mainNavigationController = mainNavigationController
-        self.storageService = storageService
-        self.userDefaultService = userDefaultService
-        self.dateManageService = dateManageService
+        self.expenseRepository = expenseRepository
+        self.currencyRepository = currencyRepository
+        self.dateRepository = dateRepository
         
         self.day = day
         weekIndex = index
@@ -40,10 +40,6 @@ final class CalendarListViewCoordinator: Coordinator {
     }
     
     func start() {
-        let expenseRepository = DefaultExpenseRepository(service: storageService)
-        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
-        let dateRepository = DefaultDateRepository(service: dateManageService)
-        
         let calendarListViewReactor = CalendarListReactor(
             expenseRepository: expenseRepository,
             dateRepository: dateRepository,
@@ -72,8 +68,8 @@ extension CalendarListViewCoordinator {
     func presentDetailView(expense: Receipt) {
         let detailViewCoordinator = DetailViewCoordinator(
             mainNavigationController: subNavigationController,
-            storageService: storageService,
-            userDefaultService: userDefaultService,
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository,
             expense: expense
         )
         

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/CalendarViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/CalendarViewCoordinator.swift
@@ -16,27 +16,23 @@ final class CalendarViewCoordinator: Coordinator {
     
     var viewController: UIViewController?
     
-    private let storageService: StorageService
-    private let userDefaultService: UserDefaultService
-    private let dateManageService: DateManageService
+    private let expenseRepository: ExpenseRepository
+    private let currencyRepository: CurrencyRepository
+    private let dateRepository: DateRepository
     
     init(
         navigationController: UINavigationController?,
-        storageService: StorageService,
-        userDefaultService: UserDefaultService,
-        dateManageService: DateManageService
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository,
+        dateRepository: DateRepository
     ) {
         self.mainNavigationController = navigationController
-        self.storageService = storageService
-        self.userDefaultService = userDefaultService
-        self.dateManageService = dateManageService
+        self.expenseRepository = expenseRepository
+        self.currencyRepository = currencyRepository
+        self.dateRepository = dateRepository
     }
     
     func start() {
-        let expenseRepository = DefaultExpenseRepository(service: storageService)
-        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
-        let dateRepository = DefaultDateRepository(service: dateManageService)
-        
         let calendarViewReactor = CalendarViewReactor(
             expenseRepository: expenseRepository,
             currencyRepository: currencyRepository,
@@ -59,9 +55,9 @@ extension CalendarViewCoordinator {
     func presentCalendarList(day: String, index: Int) {
         let calendarListViewCoordinator = CalendarListViewCoordinator(
             mainNavigationController: mainNavigationController,
-            storageService: storageService,
-            userDefaultService: userDefaultService,
-            dateManageService: dateManageService,
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository,
+            dateRepository: dateRepository,
             day: day,
             index: index
         )

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/CalendarViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/CalendarViewCoordinator.swift
@@ -33,11 +33,16 @@ final class CalendarViewCoordinator: Coordinator {
     }
     
     func start() {
+        let expenseRepository = DefaultExpenseRepository(service: storageService)
+        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
+        let dateRepository = DefaultDateRepository(service: dateManageService)
+        
         let calendarViewReactor = CalendarViewReactor(
-            storageService: storageService,
-            userDefaultService: userDefaultService,
-            dateManageService: dateManageService
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository,
+            dateRepository: dateRepository
         )
+        
         let calendarViewContoller = CalendarViewController(reactor: calendarViewReactor)
         calendarViewContoller.coordinator = self
         viewController = calendarViewContoller

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/ComposeViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/ComposeViewCoordinator.swift
@@ -19,8 +19,8 @@ final class ComposeViewCoordinator: Coordinator {
     var mainNavigationController: UINavigationController?
     var subNavigationController: UINavigationController?
     
-    private let storageService: StorageService
-    private let userDefaultService: UserDefaultService
+    private let expenseRepository: ExpenseRepository
+    private let currencyRepository: CurrencyRepository
     
     private let expense: Receipt?
     private let transitionType: TransitionType
@@ -28,21 +28,20 @@ final class ComposeViewCoordinator: Coordinator {
     init(
         transitionType: TransitionType,
         mainNavigationController: UINavigationController?,
-        storageService: StorageService,
-        userDefaultService: UserDefaultService,
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository,
         expense: Receipt?
     ) {
         self.transitionType = transitionType
         self.mainNavigationController = mainNavigationController
-        self.storageService = storageService
-        self.userDefaultService = userDefaultService
+        self.expenseRepository = expenseRepository
+        self.currencyRepository = currencyRepository
         self.expense = expense
         self.subNavigationController = UINavigationController()
     }
     
     func start() {
-        let ocrExtractor = DefaultOCRExtractorService(currencyIndex: try? userDefaultService.event.value())
-        let expenseRepository = DefaultExpenseRepository(service: storageService)
+        let ocrExtractor = DefaultOCRExtractorService(currencyIndex: currencyRepository.fetch())
         let ocrRepository = DefaultOCRRepository(service: ocrExtractor)
         
         let composeViewReactor = ComposeViewReactor(

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/ComposeViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/ComposeViewCoordinator.swift
@@ -41,7 +41,7 @@ final class ComposeViewCoordinator: Coordinator {
     }
     
     func start() {
-        let ocrExtractor = DefaultOCRExtractorService(currencyIndex: currencyRepository.fetch())
+        let ocrExtractor = DefaultOCRExtractorService(currencyIndex: currencyRepository.fetchCurrencyIndex())
         let ocrRepository = DefaultOCRRepository(service: ocrExtractor)
         
         let composeViewReactor = ComposeViewReactor(

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/ComposeViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/ComposeViewCoordinator.swift
@@ -42,13 +42,15 @@ final class ComposeViewCoordinator: Coordinator {
     
     func start() {
         let ocrExtractor = DefaultOCRExtractorService(currencyIndex: try? userDefaultService.event.value())
+        let expenseRepository = DefaultExpenseRepository(service: storageService)
+        let ocrRepository = DefaultOCRRepository(service: ocrExtractor)
         
         let composeViewReactor = ComposeViewReactor(
-            storageService: storageService,
-            ocrExtractor: ocrExtractor,
+            expenseRepository: expenseRepository,
+            ocrRepository: ocrRepository,
             expense: expense,
-            transisionType: transitionType
-        )
+            transisionType: transitionType)
+        
         let composeViewController = ComposeViewController(reactor: composeViewReactor)
         composeViewController.coordinator = self
         

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/DetailViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/DetailViewCoordinator.swift
@@ -14,28 +14,28 @@ final class DetailViewCoordinator: Coordinator {
     var mainNavigationController: UINavigationController?
     var subNavigationController: UINavigationController?
     
-    private let storageService: StorageService
-    private let userDefaultService: UserDefaultService
+    private let expenseRepository: ExpenseRepository
+    private let currencyRepository: CurrencyRepository
     
     private let expense: Receipt
     
     init(
         mainNavigationController: UINavigationController?,
-        storageService: StorageService,
-        userDefaultService: UserDefaultService,
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository,
         expense: Receipt
     ) {
         self.mainNavigationController = mainNavigationController
-        self.storageService = storageService
-        self.userDefaultService = userDefaultService
+        self.expenseRepository = expenseRepository
+        self.currencyRepository = currencyRepository
         self.expense = expense
     }
     
     func start() {
         let detailViewReactor = DetailViewReactor(
             title: ConstantText.detail.localize(),
-            storageService: storageService,
-            userDefaultService: userDefaultService,
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository,
             item: expense
         )
         let detailViewController = DetailViewController(reactor: detailViewReactor)
@@ -55,8 +55,8 @@ extension DetailViewCoordinator {
         let composeViewCoordinator = ComposeViewCoordinator(
             transitionType: .push,
             mainNavigationController: mainNavigationController,
-            storageService: storageService,
-            userDefaultService: userDefaultService,
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository,
             expense: expense
         )
         childCoordinators.append(composeViewCoordinator)

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/ExpenseViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/ExpenseViewCoordinator.swift
@@ -55,7 +55,8 @@ final class ExpenseViewCoordinator: Coordinator {
             calendarCoordinator.viewController ?? UIViewController()
         ]
         
-        let expenseViewReactor = ExpenseViewReactor(dateService: dateManageService)
+        let dateRepository = DefaultDateRepository(service: dateManageService)
+        let expenseViewReactor = ExpenseViewReactor(dateRepository: dateRepository)
         let expenseViewController = ExpenseViewController(
             reactor: expenseViewReactor,
             childViewControllers: child

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/ExpenseViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/ExpenseViewCoordinator.swift
@@ -14,38 +14,38 @@ final class ExpenseViewCoordinator: Coordinator {
     var mainNavigationController: UINavigationController?
     var subNavigationController: UINavigationController?
     
-    private let storageService: StorageService
-    private let userDefaultService: UserDefaultService
-    private let dateManageService: DateManageService
+    private let expenseRepository: ExpenseRepository
+    private let currencyRepository: CurrencyRepository
+    private let dateRepository: DateRepository
     
     init(
         mainNavigationController: UINavigationController?,
         subNavigationController: UINavigationController?,
-        storageService: StorageService,
-        userDefaultService: UserDefaultService,
-        dateManageService: DateManageService
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository,
+        dateRepository: DateRepository
     ) {
         self.mainNavigationController = mainNavigationController
         self.subNavigationController = subNavigationController
-        self.storageService = storageService
-        self.userDefaultService = userDefaultService
-        self.dateManageService = dateManageService
+        self.expenseRepository = expenseRepository
+        self.currencyRepository = currencyRepository
+        self.dateRepository = dateRepository
     }
     
     func start() {
         let listViewCoordinator = ListViewCoordinator(
-            storageService: storageService,
-            userDefaultService: userDefaultService,
-            dateManageService: dateManageService
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository,
+            dateRepository: dateRepository
         )
         
         listViewCoordinator.start()
         
         let calendarCoordinator = CalendarViewCoordinator(
             navigationController: mainNavigationController,
-            storageService: storageService,
-            userDefaultService: userDefaultService,
-            dateManageService: dateManageService
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository,
+            dateRepository: dateRepository
         )
         
         calendarCoordinator.start()
@@ -55,7 +55,6 @@ final class ExpenseViewCoordinator: Coordinator {
             calendarCoordinator.viewController ?? UIViewController()
         ]
         
-        let dateRepository = DefaultDateRepository(service: dateManageService)
         let expenseViewReactor = ExpenseViewReactor(dateRepository: dateRepository)
         let expenseViewController = ExpenseViewController(
             reactor: expenseViewReactor,
@@ -78,8 +77,8 @@ extension ExpenseViewCoordinator {
     func moveDetailView(expense: Receipt) {
         let detailViewCoordinator = DetailViewCoordinator(
             mainNavigationController: mainNavigationController,
-            storageService: storageService,
-            userDefaultService: userDefaultService,
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository,
             expense: expense
         )
         
@@ -92,8 +91,8 @@ extension ExpenseViewCoordinator {
     func moveSearchView() {
         let searchViewCoordinator = SearchViewCoordinator(
             mainNavigationController: subNavigationController,
-            storageService: storageService,
-            userDefaultService: userDefaultService
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository
         )
         
         searchViewCoordinator.parentCoordinator = self

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/ListViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/ListViewCoordinator.swift
@@ -16,25 +16,21 @@ final class ListViewCoordinator: Coordinator {
     
     var viewController: UIViewController?
     
-    private let storageService: StorageService
-    private let userDefaultService: UserDefaultService
-    private let dateManageService: DateManageService
+    private let expenseRepository: ExpenseRepository
+    private let currencyRepository: CurrencyRepository
+    private let dateRepository: DateRepository
     
     init(
-        storageService: StorageService,
-        userDefaultService: UserDefaultService,
-        dateManageService: DateManageService
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository,
+        dateRepository: DateRepository
     ) {
-        self.storageService = storageService
-        self.userDefaultService = userDefaultService
-        self.dateManageService = dateManageService
+        self.expenseRepository = expenseRepository
+        self.currencyRepository = currencyRepository
+        self.dateRepository = dateRepository
     }
     
     func start() {
-        let expenseRepository = DefaultExpenseRepository(service: storageService)
-        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
-        let dateRepository = DefaultDateRepository(service: dateManageService)
-        
         let listViewReactor = ListViewReactor(
             expenseRepository: expenseRepository,
             currencyRepository: currencyRepository,

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/ListViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/ListViewCoordinator.swift
@@ -31,11 +31,15 @@ final class ListViewCoordinator: Coordinator {
     }
     
     func start() {
+        let expenseRepository = DefaultExpenseRepository(service: storageService)
+        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
+        let dateRepository = DefaultDateRepository(service: dateManageService)
+        
         let listViewReactor = ListViewReactor(
-            storageService: storageService,
-            userDefaultService: userDefaultService,
-            dateManageService: dateManageService
-        )
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository,
+            dateRepository: dateRepository)
+        
         let listViewController = ListViewController(reactor: listViewReactor)
         listViewController.coordinator = self
         viewController = listViewController

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/MainTabBarCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/MainTabBarCoordinator.swift
@@ -15,21 +15,21 @@ final class MainTabBarCoordinator: Coordinator {
     var mainNavigationController: UINavigationController?
     var subNavigationController: UINavigationController?
     
-    private let storageService: StorageService
-    private let userDefaultService: UserDefaultService
-    private let dateManageService: DateManageService
+    private let expenseRepository: ExpenseRepository
+    private let currencyRepository: CurrencyRepository
+    private let dateRepository: DateRepository
     
     init(
         window: UIWindow?,
         mainNavigationController: UINavigationController,
-        storageService: StorageService,
-        userDefaultService: UserDefaultService,
-        dateManageService: DateManageService
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository,
+        dateRepository: DateRepository
     ) {
         self.window = window
-        self.storageService = storageService
-        self.userDefaultService = userDefaultService
-        self.dateManageService = dateManageService
+        self.expenseRepository = expenseRepository
+        self.currencyRepository = currencyRepository
+        self.dateRepository = dateRepository
         self.mainNavigationController = mainNavigationController
     }
     
@@ -43,9 +43,9 @@ final class MainTabBarCoordinator: Coordinator {
             $0.initialCoordinator(
                 mainNavigationController: mainNavigationController,
                 subNavigationController: UINavigationController(),
-                storageService: storageService,
-                userDefaultService: userDefaultService,
-                dateManageService: dateManageService
+                expenseRepository: expenseRepository,
+                currencyRepository: currencyRepository,
+                dateRepository: dateRepository
             )
         }
         
@@ -68,8 +68,8 @@ extension MainTabBarCoordinator {
         let coordinator = ComposeViewCoordinator(
             transitionType: .modal,
             mainNavigationController: mainNavigationController,
-            storageService: storageService,
-            userDefaultService: userDefaultService,
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository,
             expense: nil
         )
         

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/SearchViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/SearchViewCoordinator.swift
@@ -29,9 +29,11 @@ final class SearchViewCoordinator: Coordinator {
     }
     
     func start() {
+        let expenseRepository = DefaultExpenseRepository(service: storageService)
+        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
         let searchViewReactor = SearchViewReactor(
-            storageService: storageService,
-            userDefaultService: userDefaultService
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository
         )
         let searchViewController = SearchViewController(reactor: searchViewReactor)
         subNavigationController?.setViewControllers([searchViewController], animated: true)

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/SearchViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/SearchViewCoordinator.swift
@@ -14,23 +14,21 @@ final class SearchViewCoordinator: Coordinator {
     var mainNavigationController: UINavigationController?
     var subNavigationController: UINavigationController?
     
-    private let storageService: StorageService
-    private let userDefaultService: UserDefaultService
+    private let expenseRepository: ExpenseRepository
+    private let currencyRepository: CurrencyRepository
     
     init(
         mainNavigationController: UINavigationController?,
-        storageService: StorageService,
-        userDefaultService: UserDefaultService
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository
     ) {
         self.mainNavigationController = mainNavigationController
-        self.storageService = storageService
-        self.userDefaultService = userDefaultService
+        self.expenseRepository = expenseRepository
+        self.currencyRepository = currencyRepository
         self.subNavigationController = UINavigationController()
     }
     
     func start() {
-        let expenseRepository = DefaultExpenseRepository(service: storageService)
-        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
         let searchViewReactor = SearchViewReactor(
             expenseRepository: expenseRepository,
             currencyRepository: currencyRepository
@@ -48,8 +46,8 @@ extension SearchViewCoordinator {
     func presentDetailView(expense: Receipt) {
         let detailViewCoordinator = DetailViewCoordinator(
             mainNavigationController: subNavigationController,
-            storageService: storageService,
-            userDefaultService: userDefaultService,
+            expenseRepository: expenseRepository,
+            currencyRepository: currencyRepository,
             expense: expense
         )
         

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/SettingViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/SettingViewCoordinator.swift
@@ -27,7 +27,8 @@ final class SettingViewCoordinator: Coordinator {
     }
     
     func start() {
-        let settingViewReactor = SettingViewReactor(userDefaultService: userDefaultService)
+        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
+        let settingViewReactor = SettingViewReactor(currencyRepository: currencyRepository)
         let settingViewController = SettingViewController(reactor: settingViewReactor)
         
         settingViewController.coordinator = self

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/SettingViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/SettingViewCoordinator.swift
@@ -14,20 +14,19 @@ final class SettingViewCoordinator: Coordinator {
     var mainNavigationController: UINavigationController?
     var subNavigationController: UINavigationController?
     
-    private let userDefaultService: UserDefaultService
+    private let currencyRepository: CurrencyRepository
     
     init(
         mainNavigationController: UINavigationController?,
         subNavigationController: UINavigationController,
-        userDefaultService: UserDefaultService
+        currencyRepository: CurrencyRepository
     ) {
         self.mainNavigationController = mainNavigationController
         self.subNavigationController = subNavigationController
-        self.userDefaultService = userDefaultService
+        self.currencyRepository = currencyRepository
     }
     
     func start() {
-        let currencyRepository = DefaultCurrencyRepository(service: userDefaultService)
         let settingViewReactor = SettingViewReactor(currencyRepository: currencyRepository)
         let settingViewController = SettingViewController(reactor: settingViewReactor)
         

--- a/ReceiptManager/ReceiptManager/Source/Repository/CurrencyRepository.swift
+++ b/ReceiptManager/ReceiptManager/Source/Repository/CurrencyRepository.swift
@@ -28,6 +28,7 @@ final class DefaultCurrencyRepository: CurrencyRepository {
     }
     
     func save(index: Int) -> Observable<Int> {
+        saveEvent.onNext(index)
         return service.updateCurrency(index: index)
     }
 }

--- a/ReceiptManager/ReceiptManager/Source/Repository/CurrencyRepository.swift
+++ b/ReceiptManager/ReceiptManager/Source/Repository/CurrencyRepository.swift
@@ -1,0 +1,33 @@
+//
+//  CurrencyRepository.swift
+//  ReceiptManager
+//
+//  Created by parkhyo on 1/13/24.
+//
+
+import RxSwift
+
+protocol CurrencyRepository {
+    var saveEvent: BehaviorSubject<Int> { get }
+    
+    func fetch() -> Int
+    func save(index: Int) -> Observable<Int>
+}
+
+final class DefaultCurrencyRepository: CurrencyRepository {
+    private let service: UserDefaultService
+    let saveEvent: BehaviorSubject<Int>
+    
+    init(service: UserDefaultService) {
+        self.service = service
+        saveEvent = BehaviorSubject(value: service.fetchCurrencyIndex())
+    }
+    
+    func fetch() -> Int {
+        return service.fetchCurrencyIndex()
+    }
+    
+    func save(index: Int) -> Observable<Int> {
+        return service.updateCurrency(index: index)
+    }
+}

--- a/ReceiptManager/ReceiptManager/Source/Repository/CurrencyRepository.swift
+++ b/ReceiptManager/ReceiptManager/Source/Repository/CurrencyRepository.swift
@@ -10,8 +10,8 @@ import RxSwift
 protocol CurrencyRepository {
     var saveEvent: BehaviorSubject<Int> { get }
     
-    func fetch() -> Int
-    func save(index: Int) -> Observable<Int>
+    func fetchCurrencyIndex() -> Int
+    func updateCurrency(index: Int) -> Observable<Int>
 }
 
 final class DefaultCurrencyRepository: CurrencyRepository {
@@ -20,15 +20,15 @@ final class DefaultCurrencyRepository: CurrencyRepository {
     
     init(service: UserDefaultService) {
         self.service = service
-        saveEvent = BehaviorSubject(value: service.fetchCurrencyIndex())
+        saveEvent = BehaviorSubject(value: service.fetch())
     }
     
-    func fetch() -> Int {
-        return service.fetchCurrencyIndex()
+    func fetchCurrencyIndex() -> Int {
+        return service.fetch()
     }
     
-    func save(index: Int) -> Observable<Int> {
+    func updateCurrency(index: Int) -> Observable<Int> {
         saveEvent.onNext(index)
-        return service.updateCurrency(index: index)
+        return service.update(index: index)
     }
 }

--- a/ReceiptManager/ReceiptManager/Source/Repository/DateRepository.swift
+++ b/ReceiptManager/ReceiptManager/Source/Repository/DateRepository.swift
@@ -1,0 +1,34 @@
+//
+//  DateRepository.swift
+//  ReceiptManager
+//
+//  Created by parkhyo on 1/13/24.
+//
+
+import RxSwift
+
+protocol DateRepository {
+    func fetchActiveDate() -> Observable<Date>
+    func changeDate(byAddingMonths months: Int) -> Observable<Date>
+    func resetToToday() -> Observable<Date>
+}
+
+final class DefaultDateRepository: DateRepository {
+    private let service: DateManageService
+
+    init(service: DateManageService) {
+        self.service = service
+    }
+
+    func fetchActiveDate() -> Observable<Date> {
+        return service.currentDateEvent.asObservable()
+    }
+
+    func changeDate(byAddingMonths months: Int) -> Observable<Date> {
+        return service.updateDate(byAddingMonths: months)
+    }
+
+    func resetToToday() -> Observable<Date> {
+        return service.updateToday()
+    }
+}

--- a/ReceiptManager/ReceiptManager/Source/Repository/DateRepository.swift
+++ b/ReceiptManager/ReceiptManager/Source/Repository/DateRepository.swift
@@ -21,7 +21,7 @@ final class DefaultDateRepository: DateRepository {
     }
 
     func fetchActiveDate() -> Observable<Date> {
-        return service.fetchDate().asObservable()
+        return service.fetchDate()
     }
 
     func changeDate(byAddingMonths months: Int) -> Observable<Date> {

--- a/ReceiptManager/ReceiptManager/Source/Repository/DateRepository.swift
+++ b/ReceiptManager/ReceiptManager/Source/Repository/DateRepository.swift
@@ -21,14 +21,14 @@ final class DefaultDateRepository: DateRepository {
     }
 
     func fetchActiveDate() -> Observable<Date> {
-        return service.fetchDate()
+        return service.fetch()
     }
 
     func changeDate(byAddingMonths months: Int) -> Observable<Date> {
-        return service.updateDate(byAddingMonths: months)
+        return service.update(byAddingMonths: months)
     }
 
     func resetToToday() -> Observable<Date> {
-        return service.updateToday()
+        return service.reset()
     }
 }

--- a/ReceiptManager/ReceiptManager/Source/Repository/DateRepository.swift
+++ b/ReceiptManager/ReceiptManager/Source/Repository/DateRepository.swift
@@ -21,7 +21,7 @@ final class DefaultDateRepository: DateRepository {
     }
 
     func fetchActiveDate() -> Observable<Date> {
-        return service.currentDateEvent.asObservable()
+        return service.fetchDate().asObservable()
     }
 
     func changeDate(byAddingMonths months: Int) -> Observable<Date> {

--- a/ReceiptManager/ReceiptManager/Source/Repository/ExpenseRepository.swift
+++ b/ReceiptManager/ReceiptManager/Source/Repository/ExpenseRepository.swift
@@ -1,0 +1,43 @@
+//
+//  ExpenseRepository.swift
+//  ReceiptManager
+//
+//  Created by parkhyo on 1/13/24.
+//
+
+import RxSwift
+
+protocol ExpenseRepository {
+    var saveEvent: PublishSubject<Receipt> { get }
+    
+    func fetch() -> Observable<[Receipt]>
+    @discardableResult
+    func save(exepnse: Receipt) -> Observable<Receipt>
+    @discardableResult
+    func delete(exepnse: Receipt) -> Observable<Receipt>
+}
+
+final class DefaultExpenseRepository: ExpenseRepository {
+    private let service: StorageService
+    let saveEvent: PublishSubject<Receipt>
+    
+    init(service: StorageService) {
+        self.service = service
+        saveEvent = PublishSubject()
+    }
+    
+    func fetch() -> Observable<[Receipt]> {
+        return service.fetch()
+    }
+    
+    @discardableResult
+    func save(exepnse: Receipt) -> Observable<Receipt> {
+        saveEvent.onNext(exepnse)
+        return service.upsert(receipt: exepnse)
+    }
+    
+    @discardableResult
+    func delete(exepnse: Receipt) -> Observable<Receipt> {
+        return service.delete(receipt: exepnse)
+    }
+}

--- a/ReceiptManager/ReceiptManager/Source/Repository/ExpenseRepository.swift
+++ b/ReceiptManager/ReceiptManager/Source/Repository/ExpenseRepository.swift
@@ -10,7 +10,7 @@ import RxSwift
 protocol ExpenseRepository {
     var saveEvent: PublishSubject<Receipt> { get }
     
-    func fetch() -> Observable<[Receipt]>
+    func fetchExpenses() -> Observable<[Receipt]>
     @discardableResult
     func save(expense: Receipt) -> Observable<Receipt>
     @discardableResult
@@ -26,7 +26,7 @@ final class DefaultExpenseRepository: ExpenseRepository {
         saveEvent = PublishSubject()
     }
     
-    func fetch() -> Observable<[Receipt]> {
+    func fetchExpenses() -> Observable<[Receipt]> {
         return service.fetch()
     }
     

--- a/ReceiptManager/ReceiptManager/Source/Repository/ExpenseRepository.swift
+++ b/ReceiptManager/ReceiptManager/Source/Repository/ExpenseRepository.swift
@@ -12,9 +12,9 @@ protocol ExpenseRepository {
     
     func fetch() -> Observable<[Receipt]>
     @discardableResult
-    func save(exepnse: Receipt) -> Observable<Receipt>
+    func save(expense: Receipt) -> Observable<Receipt>
     @discardableResult
-    func delete(exepnse: Receipt) -> Observable<Receipt>
+    func delete(expense: Receipt) -> Observable<Receipt>
 }
 
 final class DefaultExpenseRepository: ExpenseRepository {
@@ -31,13 +31,13 @@ final class DefaultExpenseRepository: ExpenseRepository {
     }
     
     @discardableResult
-    func save(exepnse: Receipt) -> Observable<Receipt> {
-        saveEvent.onNext(exepnse)
-        return service.upsert(receipt: exepnse)
+    func save(expense: Receipt) -> Observable<Receipt> {
+        saveEvent.onNext(expense)
+        return service.upsert(receipt: expense)
     }
     
     @discardableResult
-    func delete(exepnse: Receipt) -> Observable<Receipt> {
-        return service.delete(receipt: exepnse)
+    func delete(expense: Receipt) -> Observable<Receipt> {
+        return service.delete(receipt: expense)
     }
 }

--- a/ReceiptManager/ReceiptManager/Source/Repository/OCRRepository.swift
+++ b/ReceiptManager/ReceiptManager/Source/Repository/OCRRepository.swift
@@ -19,6 +19,6 @@ final class DefaultOCRRepository: OCRRepository {
     }
     
     func extractText(by data: Data) -> Observable<[String]> {
-        return service.extractText(data: data)
+        return service.extract(data: data)
     }
 }

--- a/ReceiptManager/ReceiptManager/Source/Repository/OCRRepository.swift
+++ b/ReceiptManager/ReceiptManager/Source/Repository/OCRRepository.swift
@@ -1,0 +1,24 @@
+//
+//  OCRRepository.swift
+//  ReceiptManager
+//
+//  Created by parkhyo on 1/13/24.
+//
+
+import RxSwift
+
+protocol OCRRepository {
+    func extractText(by data: Data) -> Observable<[String]>
+}
+
+final class DefaultOCRRepository: OCRRepository {
+    private let service: OCRExtractorService
+    
+    init(service: OCRExtractorService) {
+        self.service = service
+    }
+    
+    func extractText(by data: Data) -> Observable<[String]> {
+        return service.extractText(data: data)
+    }
+}

--- a/ReceiptManager/ReceiptManager/Source/Scene/AnalysisScene/AnalysisViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/AnalysisScene/AnalysisViewController.swift
@@ -100,12 +100,14 @@ extension AnalysisViewController {
         .disposed(by: disposeBag)
         
         reactor.state.map { $0.totalCount }
+            .observe(on: MainScheduler.instance)
             .map { String($0) }
             .map { ConstantText.totalCountText.localized(with: $0) }
             .bind(to: monthInfoCountLabel.rx.text)
             .disposed(by: disposeBag)
         
         reactor.state.map { $0.rate }
+            .observe(on: MainScheduler.instance)
             .withUnretained(self)
             .bind { (owner, rate) in
                 switch rate {
@@ -128,6 +130,7 @@ extension AnalysisViewController {
             reactor.state.map { $0.cashCount },
             reactor.state.map { $0.cardCount }
         )
+        .observe(on: MainScheduler.instance)
         .withUnretained(self)
         .bind { (owner, counts) in
             owner.payTypeRatingView.isHidden = counts.0 + counts.1 == .zero

--- a/ReceiptManager/ReceiptManager/Source/Scene/AnalysisScene/Reactor/AnalysisViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/AnalysisScene/Reactor/AnalysisViewReactor.swift
@@ -126,7 +126,7 @@ extension AnalysisViewReactor {
     private func loadData(by date: Date) -> Observable<(current: [Receipt], previous: [Receipt])> {
         let previousDate = Calendar.current.date(byAdding: DateComponents(month: -1), to: date)
         
-        return expenseRepository.fetch()
+        return expenseRepository.fetchExpenses()
             .map { models in
                 let groupedModels = Dictionary(grouping: models) { model in
                     DateFormatter.string(from: model.receiptDate)

--- a/ReceiptManager/ReceiptManager/Source/Scene/BookMarkScene/BookMarkViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/BookMarkScene/BookMarkViewController.swift
@@ -29,7 +29,7 @@ final class BookMarkViewController: UIViewController, View {
             
             cell.reactor = ListTableViewCellReactor(
                 expense: receipt,
-                userDefaultEvent: self?.reactor?.userDefaultEvent ?? BehaviorSubject<Int>(value: .zero)
+                userDefaultEvent: self?.reactor?.currencyEvent ?? BehaviorSubject<Int>(value: .zero)
             )
             return cell
         }
@@ -118,6 +118,7 @@ extension BookMarkViewController {
             .disposed(by: disposeBag)
         
         reactor.state.map { $0.dataError }
+            .observe(on: MainScheduler.instance)
             .compactMap { $0 }
             .bind { [weak self] error in
                 self?.coordinator?.presentAlert(error: error)

--- a/ReceiptManager/ReceiptManager/Source/Scene/BookMarkScene/Reactor/BookMarkViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/BookMarkScene/Reactor/BookMarkViewReactor.swift
@@ -85,7 +85,7 @@ extension BookMarkViewReactor {
     private func loadData() -> Observable<[ReceiptSectionModel]> {
         let dayFormat = ConstantText.dateFormatMonth.localize()
         
-        return expenseRepository.fetch()
+        return expenseRepository.fetchExpenses()
             .map { result in
                 let dictionary = Dictionary(
                     grouping: result,

--- a/ReceiptManager/ReceiptManager/Source/Scene/Common/CustomTabBar/CustomTabItem.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/Common/CustomTabBar/CustomTabItem.swift
@@ -68,41 +68,41 @@ extension CustomTabItem {
     func initialCoordinator(
         mainNavigationController: UINavigationController?,
         subNavigationController: UINavigationController,
-        storageService: StorageService,
-        userDefaultService: UserDefaultService,
-        dateManageService: DateManageService
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository,
+        dateRepository: DateRepository
     ) -> Coordinator {
         switch self {
         case .main:
             return ExpenseViewCoordinator(
                 mainNavigationController: mainNavigationController,
                 subNavigationController: subNavigationController,
-                storageService: storageService,
-                userDefaultService: userDefaultService,
-                dateManageService: dateManageService
+                expenseRepository: expenseRepository,
+                currencyRepository: currencyRepository,
+                dateRepository: dateRepository
             )
             
         case .analysis:
             return AnalysisViewCoordinator(
                 mainNavigationController: mainNavigationController,
                 subNavigationController: subNavigationController,
-                storageService: storageService,
-                userDefaultService: userDefaultService
+                expenseRepository: expenseRepository,
+                currencyRepository: currencyRepository
             )
         
         case .bookmark:
             return BookMarkViewCoordinator(
                 mainNavigationController: mainNavigationController,
                 subNavigationController: subNavigationController,
-                storageService: storageService,
-                userDefaultService: userDefaultService
+                expenseRepository: expenseRepository,
+                currencyRepository: currencyRepository
             )
             
         case .setting:
             return SettingViewCoordinator(
                 mainNavigationController: mainNavigationController,
                 subNavigationController: subNavigationController,
-                userDefaultService: userDefaultService
+                currencyRepository: currencyRepository
             )
         }
     }

--- a/ReceiptManager/ReceiptManager/Source/Scene/ComposeScene/ComposeViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ComposeScene/ComposeViewController.swift
@@ -168,6 +168,7 @@ extension ComposeViewController {
             
     private func bindState(_ reactor: ComposeViewReactor) {
         reactor.state.map { $0.transitionType }
+            .observe(on: MainScheduler.instance)
             .withUnretained(self)
             .bind { (owner, type) in
                 switch type {

--- a/ReceiptManager/ReceiptManager/Source/Scene/ComposeScene/Reactor/ComposeViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ComposeScene/Reactor/ComposeViewReactor.swift
@@ -63,19 +63,19 @@ final class ComposeViewReactor: Reactor {
     
     // Properties
     
-    private let storageService: StorageService
-    private let ocrExtractor: OCRExtractorService
+    private let expenseRepository: ExpenseRepository
+    private let ocrRepository: OCRRepository
     
     // Initializer
     
     init(
-        storageService: StorageService,
-        ocrExtractor: OCRExtractorService,
+        expenseRepository: ExpenseRepository,
+        ocrRepository: OCRRepository,
         expense: Receipt? = nil,
         transisionType: TransitionType
     ) {
-        self.storageService = storageService
-        self.ocrExtractor = ocrExtractor
+        self.expenseRepository = expenseRepository
+        self.ocrRepository = ocrRepository
         
         let titleText = transisionType == .modal ?
             ConstantText.registerTitle.localize() : ConstantText.editTitle.localize()
@@ -114,7 +114,7 @@ final class ComposeViewReactor: Reactor {
         case .cellOCRButtonTapped(let indexPath):
             guard let indexPath = indexPath else { return Observable.empty() }
             let ocrTargetData = currentState.registerdImageDatas[indexPath.row]
-            return ocrExtractor.extractText(data: ocrTargetData)
+            return ocrRepository.extractText(by: ocrTargetData)
                 .flatMap { texts in
                     return Observable.concat([
                         Observable.just(Mutation.imageDataOCR(texts)),
@@ -130,7 +130,7 @@ final class ComposeViewReactor: Reactor {
             
         case .registerButtonTapped(let saveExpense):
             let newExpense = convertExpense(expense: currentState.expense, saveExpense)
-            return storageService.upsert(receipt: newExpense)
+            return expenseRepository.save(expense: newExpense)
                 .flatMap { _ in
                     Observable.concat([
                         Observable.just(Mutation.saveExpense(Void())),

--- a/ReceiptManager/ReceiptManager/Source/Scene/DetailScene/Reactor/DetailViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/DetailScene/Reactor/DetailViewReactor.swift
@@ -128,7 +128,7 @@ final class DetailViewReactor: Reactor {
 
 extension DetailViewReactor {
     private func changeState(currentState: State, data: Receipt) -> State {
-        let currencyIndex = currencyRepository.fetch()
+        let currencyIndex = currencyRepository.fetchCurrencyIndex()
         let currency = Currency(rawValue: currencyIndex) ?? .KRW
         
         var newState = currentState

--- a/ReceiptManager/ReceiptManager/Source/Scene/DetailScene/Reactor/DetailViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/DetailScene/Reactor/DetailViewReactor.swift
@@ -41,19 +41,19 @@ final class DetailViewReactor: Reactor {
     
     // Properties
     
-    private let storageService: StorageService
-    private let userDefaultService: UserDefaultService
+    private let expenseRepository: ExpenseRepository
+    private let currencyRepository: CurrencyRepository
     
     // Initializer
     
     init(
         title: String,
-        storageService: StorageService,
-        userDefaultService: UserDefaultService,
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository,
         item: Receipt
     ) {
-        self.storageService = storageService
-        self.userDefaultService = userDefaultService
+        self.expenseRepository = expenseRepository
+        self.currencyRepository = currencyRepository
        
         initialState = State(title: title, expense: item, priceText: "")
     }
@@ -79,7 +79,7 @@ final class DetailViewReactor: Reactor {
             
         case .delete:
             let expense = currentState.expense
-            return storageService.delete(receipt: expense)
+            return expenseRepository.delete(expense: expense)
                 .flatMap { _ in
                     return Observable.just(Mutation.deleteExpense(Void()))
                 }
@@ -119,7 +119,7 @@ final class DetailViewReactor: Reactor {
     }
     
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
-        let updateEvent = storageService.updateEvent
+        let updateEvent = expenseRepository.saveEvent
             .flatMap { Observable.just(Mutation.updateExpense($0)) }
         
         return Observable.merge(mutation, updateEvent)
@@ -128,7 +128,7 @@ final class DetailViewReactor: Reactor {
 
 extension DetailViewReactor {
     private func changeState(currentState: State, data: Receipt) -> State {
-        let currencyIndex = userDefaultService.fetchCurrencyIndex()
+        let currencyIndex = currencyRepository.fetch()
         let currency = Currency(rawValue: currencyIndex) ?? .KRW
         
         var newState = currentState

--- a/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/CalendarListScene/CalendarListViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/CalendarListScene/CalendarListViewController.swift
@@ -129,6 +129,7 @@ extension CalendarListViewController {
             .disposed(by: disposeBag)
         
         reactor.state.map { $0.dataError }
+            .observe(on: MainScheduler.instance)
             .compactMap { $0 }
             .bind { [weak self] error in
                 self?.coordinator?.presentAlert(error: error)

--- a/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/CalendarListScene/CalendarListViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/CalendarListScene/CalendarListViewController.swift
@@ -123,7 +123,7 @@ extension CalendarListViewController {
             ) { [weak self] indexPath, data, cell in
                 cell.reactor = ListTableViewCellReactor(
                     expense: data,
-                    userDefaultEvent: self?.reactor?.userDefaultEvent ?? BehaviorSubject(value: .zero)
+                    userDefaultEvent: self?.reactor?.currentEvent ?? BehaviorSubject(value: .zero)
                 )
             }
             .disposed(by: disposeBag)

--- a/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/CalendarListScene/Reactor/CalendarListReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/CalendarListScene/Reactor/CalendarListReactor.swift
@@ -138,7 +138,7 @@ extension CalendarListReactor {
     private func loadData(date: String) -> Observable<[Receipt]> {
         let dayFormat = ConstantText.dateFormatFull.localize()
         
-        return expenseRepository.fetch()
+        return expenseRepository.fetchExpenses()
             .map { datas in
                 return datas.filter { expense in
                     let expenseDate = DateFormatter.string(from: expense.receiptDate, dayFormat)

--- a/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/CalendarListScene/Reactor/CalendarListReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/CalendarListScene/Reactor/CalendarListReactor.swift
@@ -37,22 +37,22 @@ final class CalendarListReactor: Reactor {
     
     // Properties
     
-    private let storageService: StorageService
-    private let dateManageService: DateManageService
-    let userDefaultEvent: BehaviorSubject<Int>
+    private let expenseRepository: ExpenseRepository
+    private let dateRepository: DateRepository
+    let currentEvent: BehaviorSubject<Int>
     
     // Initializer
     
     init(
-        storageService: StorageService,
-        userDefaultService: UserDefaultService,
-        dateManageService: DateManageService,
+        expenseRepository: ExpenseRepository,
+        dateRepository: DateRepository,
+        currencyRepository: CurrencyRepository,
         day: String,
         weekIndex: Int
     ) {
-        self.storageService = storageService
-        self.userDefaultEvent = userDefaultService.event
-        self.dateManageService = dateManageService
+        self.expenseRepository = expenseRepository
+        self.dateRepository = dateRepository
+        self.currentEvent = currencyRepository.saveEvent
         
         initialState = State(
             dateTitle: "",
@@ -68,23 +68,26 @@ final class CalendarListReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> { 
         switch action {
         case .loadData:
-            return Observable.concat([
-                Observable.just(Mutation.updateDateTitle(updateDate())),
-                loadData().flatMap({ [weak self] models in
-                    return Observable.concat([
-                        Observable.just(Mutation.updateExpenseList(models)),
-                        Observable.just(Mutation.updateAmount(self?.updateAmount(models) ?? "" ))
-                    ])
-                })
-            ])
+            return updateDate()
+                .withUnretained(self)
+                .flatMap { (owner, date) in
+                    owner.loadData(date: date)
+                        .flatMap { expenses in
+                            Observable.merge([
+                                Observable.just(Mutation.updateDateTitle(date)),
+                                Observable.just(Mutation.updateExpenseList(expenses))
+                            ])
+                        }
+                }
             
         case .cellBookMark(let indexPath):
             var expense = currentState.expenseByDay[indexPath.row]
             expense.isFavorite.toggle()
-            return storageService.upsert(receipt: expense)
+            
+            return expenseRepository.save(expense: expense)
                 .withUnretained(self)
                 .flatMap { (owner, _) in
-                    owner.loadData().map { models in
+                    owner.loadData(date: owner.currentState.dateTitle).map { models in
                         Mutation.updateExpenseList(models)}
                 }
                 .catch { error in
@@ -96,10 +99,10 @@ final class CalendarListReactor: Reactor {
             
         case .cellDelete(let indexPath):
             let expense = currentState.expenseByDay[indexPath.row]
-            return storageService.delete(receipt: expense)
+            return expenseRepository.delete(expense: expense)
                 .withUnretained(self)
                 .flatMap { (owner, _) in
-                    owner.loadData().map { models in
+                    owner.loadData(date: owner.currentState.dateTitle).map { models in
                         Mutation.updateExpenseList(models)}
                 }
                 .catch { error in
@@ -132,36 +135,32 @@ final class CalendarListReactor: Reactor {
 }
 
 extension CalendarListReactor {
-    private func loadData() -> Observable<[Receipt]> {
-        return storageService.fetch()
-            .distinctUntilChanged()
-            .withUnretained(self)
-            .map { (owner, item) in
-                owner.filterData(for: item)
-            }
-    }
-    
-    private func filterData(for data: [Receipt]) -> [Receipt] {
+    private func loadData(date: String) -> Observable<[Receipt]> {
         let dayFormat = ConstantText.dateFormatFull.localize()
-        let currentDate = updateDate()
         
-        return data.filter { expense in
-            let expenseDate = DateFormatter.string(from: expense.receiptDate, dayFormat)
-            return expenseDate == currentDate
-        }
+        return expenseRepository.fetch()
+            .map { datas in
+                return datas.filter { expense in
+                    let expenseDate = DateFormatter.string(from: expense.receiptDate, dayFormat)
+                    return expenseDate == date
+                }
+            }
     }
 }
 
 extension CalendarListReactor {
-    private func updateDate() -> String {
-        let date = (try? dateManageService.currentDateEvent.value()) ?? Date()
-        
-        let day = currentState.day
-        let month = DateFormatter.month(from: date)
-        let year = DateFormatter.year(from: date)
-        
-        let newDate = createDateFromComponents(year: year, month: month, day: Int(day))
-        return DateFormatter.string(from: newDate ?? Date(), ConstantText.dateFormatFull.localize())
+    private func updateDate() -> Observable<String> {
+        return dateRepository.fetchActiveDate()
+            .map { [weak self] date in
+                guard let self = self else { return "" }
+                
+                let day = self.currentState.day
+                let month = DateFormatter.month(from: date)
+                let year = DateFormatter.year(from: date)
+                let newDate = self.createDateFromComponents(year: year, month: month, day: Int(day))
+                
+                return DateFormatter.string(from: newDate ?? Date(), ConstantText.dateFormatFull.localize())
+            }
     }
     
     private func createDateFromComponents(year: Int?, month: Int?, day: Int?) -> Date? {

--- a/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/CalendarViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/CalendarViewController.swift
@@ -102,7 +102,7 @@ extension CalendarViewController: UICollectionViewDelegate {
                     count: data.countOfExpense,
                     amount: data.amountOfExpense,
                     isToday: data.isToday,
-                    userDefaultEvent: self.reactor?.userDefaultEvent ?? BehaviorSubject<Int>(value: .zero)
+                    userDefaultEvent: self.reactor?.currencyRepository.saveEvent ?? BehaviorSubject<Int>(value: .zero)
                 )
             }
             .disposed(by: disposeBag)

--- a/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/Reactor/CalendarViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/Reactor/CalendarViewReactor.swift
@@ -38,20 +38,20 @@ final class CalendarViewReactor: Reactor {
     }
     
     private let calendar: Calendar
-    private let storageService: StorageService
-    let userDefaultEvent: BehaviorSubject<Int>
-    let dateManageEvent: BehaviorSubject<Date>
+    private let expenseRepository: ExpenseRepository
+    let currencyRepository: CurrencyRepository
+    private let dateRepository: DateRepository
     
     // Initializer
     
     init(
-        storageService: StorageService,
-        userDefaultService: UserDefaultService,
-        dateManageService: DateManageService
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository,
+        dateRepository: DateRepository
     ) {
-        self.storageService = storageService
-        userDefaultEvent = userDefaultService.event
-        dateManageEvent = dateManageService.currentDateEvent
+        self.expenseRepository = expenseRepository
+        self.currencyRepository = currencyRepository
+        self.dateRepository = dateRepository
         
         calendar = Calendar.current
         initialState = State(expenseByMonth: [], date: Date(), dayInfos: [])
@@ -84,7 +84,7 @@ final class CalendarViewReactor: Reactor {
     }
     
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
-        let dateEvent = dateManageEvent
+        let dateEvent = dateRepository.fetchActiveDate()
             .flatMap { date in
                 return Observable.concat(
                     Observable.just(Mutation.changeMonth(date)),
@@ -106,7 +106,7 @@ extension CalendarViewReactor {
     private func loadData(by date: Date?) -> Observable<[ReceiptSectionModel]> {
         let dayFormat = ConstantText.dateFormatFull.localize()
         
-        return storageService.fetch()
+        return expenseRepository.fetch()
             .map { result in
                 let dictionary = Dictionary(
                     grouping: result,

--- a/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/Reactor/CalendarViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/Reactor/CalendarViewReactor.swift
@@ -106,7 +106,7 @@ extension CalendarViewReactor {
     private func loadData(by date: Date?) -> Observable<[ReceiptSectionModel]> {
         let dayFormat = ConstantText.dateFormatFull.localize()
         
-        return expenseRepository.fetch()
+        return expenseRepository.fetchExpenses()
             .map { result in
                 let dictionary = Dictionary(
                     grouping: result,

--- a/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/ListScene/ListViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/ListScene/ListViewController.swift
@@ -30,7 +30,7 @@ final class ListViewController: UIViewController, View {
             
             cell.reactor = ListTableViewCellReactor(
                 expense: receipt,
-                userDefaultEvent: self.reactor?.userDefaultEvent ?? BehaviorSubject<Int>(value: .zero)
+                userDefaultEvent: self.reactor?.currencyRepository.saveEvent ?? BehaviorSubject<Int>(value: .zero)
             )
             
             return cell
@@ -123,6 +123,7 @@ extension ListViewController {
             .disposed(by: disposeBag)
         
         reactor.state.map { $0.dataError }
+            .observe(on: MainScheduler.instance)
             .compactMap { $0 }
             .bind { [weak self] error in
                 self?.coordinator?.presentAlert(error: error)

--- a/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/ListScene/Reactor/ListViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/ListScene/Reactor/ListViewReactor.swift
@@ -128,7 +128,7 @@ extension ListViewReactor {
     private func loadData() -> Observable<[ReceiptSectionModel]> {
         let dayFormat = ConstantText.dateFormatFull.localize()
         
-        return expenseRepository.fetch()
+        return expenseRepository.fetchExpenses()
             .distinctUntilChanged()
             .map { result in
                 let dictionary = Dictionary(

--- a/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/ListScene/Reactor/ListViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/ListScene/Reactor/ListViewReactor.swift
@@ -33,20 +33,20 @@ final class ListViewReactor: Reactor {
     
     // Properties
     
-    private let storageService: StorageService
-    let userDefaultEvent: BehaviorSubject<Int>
-    let dateManageEvent: BehaviorSubject<Date>
+    private let expenseRepository: ExpenseRepository
+    let currencyRepository: CurrencyRepository
+    private let dateRepository: DateRepository
     
     // Initializer
     
     init(
-        storageService: StorageService,
-        userDefaultService: UserDefaultService,
-        dateManageService: DateManageService
+        expenseRepository: ExpenseRepository,
+        currencyRepository: CurrencyRepository,
+        dateRepository: DateRepository
     ) {
-        self.storageService = storageService
-        userDefaultEvent = userDefaultService.event
-        dateManageEvent = dateManageService.currentDateEvent
+        self.expenseRepository = expenseRepository
+        self.currencyRepository = currencyRepository
+        self.dateRepository = dateRepository
         initialState = State(expenseByMonth: [], date: Date())
     }
     
@@ -62,7 +62,7 @@ final class ListViewReactor: Reactor {
         case .cellBookMark(let indexPath):
             var expense = currentState.expenseByMonth[indexPath.section].items[indexPath.row]
             expense.isFavorite.toggle()
-            return storageService.upsert(receipt: expense)
+            return expenseRepository.save(expense: expense)
                 .flatMap { _ in
                     self.loadData().map { models in
                         Mutation.updateExpenseList(self.filterData(by: self.currentState.date, for: models))
@@ -77,7 +77,7 @@ final class ListViewReactor: Reactor {
 
         case .cellDelete(let indexPath):
             let expense = currentState.expenseByMonth[indexPath.section].items[indexPath.row]
-            return storageService.delete(receipt: expense)
+            return expenseRepository.delete(expense: expense)
                 .flatMap { _ in
                     self.loadData().map { models in
                         Mutation.updateExpenseList(self.filterData(by: self.currentState.date, for: models))
@@ -110,7 +110,7 @@ final class ListViewReactor: Reactor {
     }
     
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
-        let dateEvent = dateManageEvent
+        let dateEvent = dateRepository.fetchActiveDate()
             .flatMap { date in
                 return Observable.concat(
                     Observable.just(Mutation.changeMonth(date)),
@@ -128,7 +128,7 @@ extension ListViewReactor {
     private func loadData() -> Observable<[ReceiptSectionModel]> {
         let dayFormat = ConstantText.dateFormatFull.localize()
         
-        return storageService.fetch()
+        return expenseRepository.fetch()
             .distinctUntilChanged()
             .map { result in
                 let dictionary = Dictionary(

--- a/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/Reactor/ExpenseViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/Reactor/ExpenseViewReactor.swift
@@ -38,16 +38,16 @@ final class ExpenseViewReactor: Reactor {
     
     // Properties
     
-    private let dateService: DateManageService
+    private let dateRepository: DateRepository
     
     // Initializer
     
-    init(dateService: DateManageService) {
-        self.dateService = dateService
+    init(dateRepository: DateRepository) {
+        self.dateRepository = dateRepository
         initialState = State(
             title: ConstantText.list.localize(),
             showMode: .list,
-            dateToShow: (try? dateService.currentDateEvent.value()) ?? Date()
+            dateToShow: Date()
         )
     }
 
@@ -60,15 +60,15 @@ final class ExpenseViewReactor: Reactor {
             return .just(.changeShowMode(newMode))
         
         case .nextMonthButtonTapped:
-            return dateService.updateDate(byAddingMonths: 1)
+            return dateRepository.changeDate(byAddingMonths: 1)
                 .flatMap { Observable.just(Mutation.updateDate($0)) }
             
         case .previousMonthButtonTapped:
-            return dateService.updateDate(byAddingMonths: -1)
+            return dateRepository.changeDate(byAddingMonths: -1)
                 .flatMap { Observable.just(Mutation.updateDate($0)) }
             
         case .todayButtonTapped:
-            return dateService.updateToday()
+            return dateRepository.resetToToday()
                 .flatMap { Observable.just(Mutation.updateDate($0)) }
         }
     }

--- a/ReceiptManager/ReceiptManager/Source/Scene/SearchScene/Reactor/SearchViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/SearchScene/Reactor/SearchViewReactor.swift
@@ -75,7 +75,7 @@ extension SearchViewReactor {
     private func loadData() -> Observable<[ReceiptSectionModel]> {
         let dayFormat = ConstantText.dateFormatMonth.localize()
         
-        return expenseRepository.fetch()
+        return expenseRepository.fetchExpenses()
             .map { result in
                 let dictionary = Dictionary(
                     grouping: result,

--- a/ReceiptManager/ReceiptManager/Source/Scene/SearchScene/Reactor/SearchViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/SearchScene/Reactor/SearchViewReactor.swift
@@ -29,14 +29,14 @@ final class SearchViewReactor: Reactor {
     
     // Properties
     
-    private let storageService: StorageService
-    let userDefaultEvent: BehaviorSubject<Int>
+    private let expenseRepository: ExpenseRepository
+    let currencyEvent: BehaviorSubject<Int>
     
     // Initializer
     
-    init(storageService: StorageService, userDefaultService: UserDefaultService) {
-        self.storageService = storageService
-        userDefaultEvent = userDefaultService.event
+    init(expenseRepository: ExpenseRepository, currencyRepository: CurrencyRepository) {
+        self.expenseRepository = expenseRepository
+        currencyEvent = currencyRepository.saveEvent
         initialState = State(title: ConstantText.searchBar.localize(), searchText: "", searchResult: [])
     }
     
@@ -75,7 +75,7 @@ extension SearchViewReactor {
     private func loadData() -> Observable<[ReceiptSectionModel]> {
         let dayFormat = ConstantText.dateFormatMonth.localize()
         
-        return storageService.fetch()
+        return expenseRepository.fetch()
             .map { result in
                 let dictionary = Dictionary(
                     grouping: result,

--- a/ReceiptManager/ReceiptManager/Source/Scene/SearchScene/SearchViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/SearchScene/SearchViewController.swift
@@ -29,7 +29,7 @@ final class SearchViewController: UIViewController, View {
             
             cell.reactor = ListTableViewCellReactor(
                 expense: receipt,
-                userDefaultEvent: self?.reactor?.userDefaultEvent ?? BehaviorSubject<Int>(value: .zero)
+                userDefaultEvent: self?.reactor?.currencyEvent ?? BehaviorSubject<Int>(value: .zero)
             )
             return cell
         }
@@ -154,6 +154,7 @@ extension SearchViewController {
     
     private func bindState(_ reactor: SearchViewReactor) {
         reactor.state.map { $0.searchResult }
+            .observe(on: MainScheduler.instance)
             .do(onNext: { [weak self] datas in
                 datas.isEmpty ? self?.showEmptyResultMessage() : self?.hideEmptyResultMessage()
             })

--- a/ReceiptManager/ReceiptManager/Source/Scene/SettingScene/Reactor/SettingViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/SettingScene/Reactor/SettingViewReactor.swift
@@ -59,7 +59,7 @@ final class SettingViewReactor: Reactor {
             return classifySettingType(settingType)
             
         case .segmentValueChanged(let index):
-            return currencyRepository.save(index: index)
+            return currencyRepository.updateCurrency(index: index)
                 .flatMap { Observable.just(Mutation.currencyChange($0)) }
         }
     }

--- a/ReceiptManager/ReceiptManager/Source/Scene/SettingScene/Reactor/SettingViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/SettingScene/Reactor/SettingViewReactor.swift
@@ -33,12 +33,12 @@ final class SettingViewReactor: Reactor {
     
     // Properties
     
-    private let userDefaultService: UserDefaultService
+    private let currencyRepository: CurrencyRepository
     
     // Initializer
     
-    init(userDefaultService: UserDefaultService) {
-        self.userDefaultService = userDefaultService
+    init(currencyRepository: CurrencyRepository) {
+        self.currencyRepository = currencyRepository
         
         initialState = State(settingMenu: [], url: nil, currencyIndex: .zero)
     }
@@ -51,7 +51,7 @@ final class SettingViewReactor: Reactor {
             let settingMenu = SettingSection.configureSettings()
             return Observable.merge([
                 Observable.just(Mutation.loadData(settingMenu)),
-                userDefaultService.event.asObservable().map { Mutation.currencyChange($0) }
+                currencyRepository.saveEvent.asObservable().map { Mutation.currencyChange($0) }
             ])
         
         case .cellSelect(let indexPath):
@@ -59,7 +59,7 @@ final class SettingViewReactor: Reactor {
             return classifySettingType(settingType)
             
         case .segmentValueChanged(let index):
-            return userDefaultService.updateCurrency(index: index)
+            return currencyRepository.save(index: index)
                 .flatMap { Observable.just(Mutation.currencyChange($0)) }
         }
     }

--- a/ReceiptManager/ReceiptManager/Source/Service/DateManageService.swift
+++ b/ReceiptManager/ReceiptManager/Source/Service/DateManageService.swift
@@ -9,7 +9,7 @@ import RxSwift
 
 protocol DateManageService {
     var currentDateEvent: BehaviorSubject<Date> { get }
-    
+    func fetchDate() -> Observable<Date>
     func updateDate(byAddingMonths months: Int) -> Observable<Date>
     func updateToday() -> Observable<Date>
 }
@@ -19,6 +19,10 @@ final class DefaultDateManageService: DateManageService {
     
     init() {
         currentDateEvent = BehaviorSubject(value: Date())
+    }
+    
+    func fetchDate() -> Observable<Date> {
+        return currentDateEvent.asObservable()
     }
     
     func updateDate(byAddingMonths months: Int) -> Observable<Date> {

--- a/ReceiptManager/ReceiptManager/Source/Service/DateManageService.swift
+++ b/ReceiptManager/ReceiptManager/Source/Service/DateManageService.swift
@@ -8,21 +8,20 @@
 import RxSwift
 
 protocol DateManageService {
-    var currentDateEvent: BehaviorSubject<Date> { get }
     func fetchDate() -> Observable<Date>
     func updateDate(byAddingMonths months: Int) -> Observable<Date>
     func updateToday() -> Observable<Date>
 }
 
 final class DefaultDateManageService: DateManageService {
-    var currentDateEvent: BehaviorSubject<Date>
+    private let currentDateEvent: BehaviorSubject<Date>
     
     init() {
         currentDateEvent = BehaviorSubject(value: Date())
     }
     
     func fetchDate() -> Observable<Date> {
-        return currentDateEvent.asObservable()
+        return currentDateEvent
     }
     
     func updateDate(byAddingMonths months: Int) -> Observable<Date> {

--- a/ReceiptManager/ReceiptManager/Source/Service/DateManageService.swift
+++ b/ReceiptManager/ReceiptManager/Source/Service/DateManageService.swift
@@ -8,9 +8,9 @@
 import RxSwift
 
 protocol DateManageService {
-    func fetchDate() -> Observable<Date>
-    func updateDate(byAddingMonths months: Int) -> Observable<Date>
-    func updateToday() -> Observable<Date>
+    func fetch() -> Observable<Date>
+    func update(byAddingMonths months: Int) -> Observable<Date>
+    func reset() -> Observable<Date>
 }
 
 final class DefaultDateManageService: DateManageService {
@@ -20,11 +20,11 @@ final class DefaultDateManageService: DateManageService {
         currentDateEvent = BehaviorSubject(value: Date())
     }
     
-    func fetchDate() -> Observable<Date> {
+    func fetch() -> Observable<Date> {
         return currentDateEvent
     }
     
-    func updateDate(byAddingMonths months: Int) -> Observable<Date> {
+    func update(byAddingMonths months: Int) -> Observable<Date> {
         let calendar = Calendar.current
         let currentDate = (try? currentDateEvent.value()) ?? Date()
         let updatedDate = calendar.date(byAdding: DateComponents(month: months), to: currentDate) ?? Date()
@@ -33,7 +33,7 @@ final class DefaultDateManageService: DateManageService {
         return currentDateEvent.asObservable()
     }
     
-    func updateToday() -> Observable<Date> {
+    func reset() -> Observable<Date> {
         currentDateEvent.onNext(Date())
         return currentDateEvent.asObservable()
     }

--- a/ReceiptManager/ReceiptManager/Source/Service/OCRExtractorService.swift
+++ b/ReceiptManager/ReceiptManager/Source/Service/OCRExtractorService.swift
@@ -13,7 +13,7 @@ import FirebaseCrashlytics
 import RxSwift
 
 protocol OCRExtractorService {
-    func extractText(data: Data) -> Observable<[String]>
+    func extract(data: Data) -> Observable<[String]>
 }
 
 final class DefaultOCRExtractorService: OCRExtractorService {
@@ -23,7 +23,7 @@ final class DefaultOCRExtractorService: OCRExtractorService {
         currency = Currency(rawValue: currencyIndex ?? .zero) ?? .KRW
     }
     
-    func extractText(data: Data) -> Observable<[String]> {
+    func extract(data: Data) -> Observable<[String]> {
         return Observable.create { [weak self] observer in
             guard let self = self, let image = UIImage(data: data)?.cgImage else {
                 observer.onError(OCRExtractorError.extractError)

--- a/ReceiptManager/ReceiptManager/Source/Service/OCRExtractorService.swift
+++ b/ReceiptManager/ReceiptManager/Source/Service/OCRExtractorService.swift
@@ -32,9 +32,7 @@ final class DefaultOCRExtractorService: OCRExtractorService {
             
             let handler = VNImageRequestHandler(cgImage: image, options: [:])
             
-            let request = VNRecognizeTextRequest { [weak self] request, error in
-                guard let self = self else { return }
-                
+            let request = VNRecognizeTextRequest { request, error in
                 guard let observations = request.results as? [VNRecognizedTextObservation], error == nil
                 else {
                     observer.onError(OCRExtractorError.extractError)

--- a/ReceiptManager/ReceiptManager/Source/Service/StorageService.swift
+++ b/ReceiptManager/ReceiptManager/Source/Service/StorageService.swift
@@ -13,17 +13,12 @@ import RxCoreData
 
 protocol StorageService {
     var updateEvent: PublishSubject<Receipt> { get }
-    
     func sync()
+    func fetch() -> Observable<[Receipt]>
+    func delete(receipt: Receipt) -> Observable<Receipt>
     
     @discardableResult
     func upsert(receipt: Receipt) -> Observable<Receipt>
-    
-    @discardableResult
-    func fetch() -> Observable<[Receipt]>
-    
-    @discardableResult
-    func delete(receipt: Receipt) -> Observable<Receipt>
 }
 
 final class DefaultStorageService: StorageService {
@@ -94,7 +89,6 @@ final class DefaultStorageService: StorageService {
         }
     }
     
-    @discardableResult
     func delete(receipt: Receipt) -> Observable<Receipt> {
         do {
             try context.rx.delete(receipt)

--- a/ReceiptManager/ReceiptManager/Source/Service/StorageService.swift
+++ b/ReceiptManager/ReceiptManager/Source/Service/StorageService.swift
@@ -12,7 +12,6 @@ import RxSwift
 import RxCoreData
 
 protocol StorageService {
-    var updateEvent: PublishSubject<Receipt> { get }
     func sync()
     func fetch() -> Observable<[Receipt]>
     func delete(receipt: Receipt) -> Observable<Receipt>
@@ -45,11 +44,9 @@ final class DefaultStorageService: StorageService {
     
     private let modelName: String
     private let disposeBag = DisposeBag()
-    let updateEvent: PublishSubject<Receipt>
     
     init(modelName: String) {
         self.modelName = modelName
-        updateEvent = PublishSubject()
     }
     
     func sync() {
@@ -79,8 +76,6 @@ final class DefaultStorageService: StorageService {
     
     @discardableResult
     func upsert(receipt: Receipt) -> Observable<Receipt> {
-        updateEvent.onNext(receipt)
-        
         return Observable.create { [weak self] observer in
             self?.context.perform {
                 do {

--- a/ReceiptManager/ReceiptManager/Source/Service/UserDefaultService.swift
+++ b/ReceiptManager/ReceiptManager/Source/Service/UserDefaultService.swift
@@ -8,8 +8,6 @@
 import RxSwift
 
 protocol UserDefaultService {
-    var event: BehaviorSubject<Int> { get }
-    
     func fetchCurrencyIndex() -> Int
     func updateCurrency(index: Int) -> Observable<Int>
 }
@@ -18,19 +16,12 @@ final class DefaultUserDefaultService: UserDefaultService {
     
     private let storage = UserDefaults.standard
     
-    let event: BehaviorSubject<Int>
-    
-    init() {
-        event = BehaviorSubject(value: storage.integer(forKey: ConstantText.currencyKey))
-    }
-    
     func fetchCurrencyIndex() -> Int {
         return storage.integer(forKey: ConstantText.currencyKey)
     }
     
     func updateCurrency(index: Int) -> Observable<Int> {
         storage.set(index, forKey: ConstantText.currencyKey)
-        event.onNext(index)
-        return event.asObservable()
+        return Observable.just(fetchCurrencyIndex())
     }
 }

--- a/ReceiptManager/ReceiptManager/Source/Service/UserDefaultService.swift
+++ b/ReceiptManager/ReceiptManager/Source/Service/UserDefaultService.swift
@@ -8,20 +8,20 @@
 import RxSwift
 
 protocol UserDefaultService {
-    func fetchCurrencyIndex() -> Int
-    func updateCurrency(index: Int) -> Observable<Int>
+    func fetch() -> Int
+    func update(index: Int) -> Observable<Int>
 }
 
 final class DefaultUserDefaultService: UserDefaultService {
     
     private let storage = UserDefaults.standard
     
-    func fetchCurrencyIndex() -> Int {
+    func fetch() -> Int {
         return storage.integer(forKey: ConstantText.currencyKey)
     }
     
-    func updateCurrency(index: Int) -> Observable<Int> {
+    func update(index: Int) -> Observable<Int> {
         storage.set(index, forKey: ConstantText.currencyKey)
-        return Observable.just(fetchCurrencyIndex())
+        return Observable.just(fetch())
     }
 }


### PR DESCRIPTION
## 주요 변경 사항
1. CoreData 비동기로 동작하도록 수정
2. Service의 변경에 대해서 Reactor의 변동성을 낮추기 위해 Repository 패턴 도입

## 과정
1. CoreData 비동기로 동작하도록 수정
- 기존의 CoreData Context는 viewContext(Main Queue)에서 CRUD를 진행하였습니다.
- 하지만, 동기적으로 동작하기 때문에 내부의 CRUD가 오래 걸린다면 UI가 멈추는 것을 확인하였습니다. (Thread.sleep으로 임시 확인)
- 때문에 backgroundContext를 통해 다른 스레드에서 CRUD가 진행되도록 수정하였으며, background Context는 perform 블럭(비동기 메서드) 내부에서 동기적으로 실행시키기 때문에 원하는 비동기 효과를 부여할 수 있었습니다.

2. Service의 변경에 대해서 Reactor의 변동성을 낮추기 위해 Repository 패턴 도입
- 기존은 Reactor과 Service가 직접적으로 참조가 되어있기 때문에 Service 내부의 코드들이 상세 변경되고, Service의 Interface가 수정된다면  Reactor의 변경도가 매우 컸습니다.
- 중간에 Repository Interface와 Repository 구체타입을 추가함으로서 Service의 로직이 변경되더라도 Repository Interface가 변경되지 않는 이상 Reactor는 변경도가 없으며, Repository의 구체타입만 수정하면 되기 때문에 Reactor의 수정도를 낮출 수 있었습니다.