### PR TITLE
[Version/2.0.1] OCR Error Handling

### DIFF
--- a/ReceiptManager/ReceiptManager/Localizing/en.lproj/Localizable.strings
+++ b/ReceiptManager/ReceiptManager/Localizing/en.lproj/Localizable.strings
@@ -23,6 +23,7 @@
 "delete" = "Delete";
 
 "cancle" = "Cancel";
+"retry" = "Retry";
 "close" = "Close";
 "complete" = "Completed";
 "edit" = "Edit";

--- a/ReceiptManager/ReceiptManager/Localizing/ja.lproj/Localizable.strings
+++ b/ReceiptManager/ReceiptManager/Localizing/ja.lproj/Localizable.strings
@@ -23,6 +23,7 @@
 "delete" = "削除";
 
 "cancle" = "キャンセル";
+"retry" = "もう一度";
 "close" = "終了";
 "complete" = "完了";
 "edit" = "編集";

--- a/ReceiptManager/ReceiptManager/Localizing/ko.lproj/Localizable.strings
+++ b/ReceiptManager/ReceiptManager/Localizing/ko.lproj/Localizable.strings
@@ -23,6 +23,7 @@
 "delete" = "삭제";
 
 "cancle" = "취소";
+"retry" = "재시도";
 "close" = "닫기";
 "complete" = "완료";
 "edit" = "편집";

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/AlertViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/AlertViewCoordinator.swift
@@ -14,16 +14,18 @@ final class AlertViewCoordinator: Coordinator {
     var mainNavigationController: UINavigationController?
     var subNavigationController: UINavigationController?
     
+    weak var retryDelegate: Retriable?
     var error: Error
     
-    init(mainNavigationController: UINavigationController?, error: Error) {
+    init(mainNavigationController: UINavigationController?, error: Error, retryDelegate: Retriable? = nil) {
         self.mainNavigationController = mainNavigationController
         self.subNavigationController = UINavigationController()
         self.error = error
+        self.retryDelegate = retryDelegate
     }
     
     func start() {
-        let alertViewController = CustomAlertViewController(error: error)
+        let alertViewController = CustomAlertViewController(error: error, delegate: retryDelegate)
         alertViewController.coordinator = self
         
         subNavigationController?.modalPresentationStyle = .overFullScreen

--- a/ReceiptManager/ReceiptManager/Source/Coordinator/ComposeViewCoordinator.swift
+++ b/ReceiptManager/ReceiptManager/Source/Coordinator/ComposeViewCoordinator.swift
@@ -105,20 +105,22 @@ extension ComposeViewCoordinator {
         limitAlbumViewCoordinator.start()
     }
     
-    func presentAlert(error: Error) {
+    func presentAlert(error: Error, delegate: Retriable? = nil) {
         
         let alertCoordinator: AlertViewCoordinator
         switch transitionType {
         case .modal:
             alertCoordinator = AlertViewCoordinator(
                 mainNavigationController: subNavigationController,
-                error: error
+                error: error,
+                retryDelegate: delegate
             )
             
         case .push:
             alertCoordinator = AlertViewCoordinator(
                 mainNavigationController: mainNavigationController,
-                error: error
+                error: error,
+                retryDelegate: delegate
             )
         }
 

--- a/ReceiptManager/ReceiptManager/Source/Scene/Common/CustomAlert/AlertView.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/Common/CustomAlert/AlertView.swift
@@ -49,7 +49,7 @@ final class AlertView: UIView {
     
     private let retryButton: UIButton = {
         let button = UIButton()
-        button.setTitle("재시도", for: .normal)
+        button.setTitle(ConstantText.retry.localize(), for: .normal)
         button.backgroundColor = .systemGray3
         button.setTitleColor(.label, for: .normal)
         button.titleLabel?.font = .systemFont(ofSize: 15)

--- a/ReceiptManager/ReceiptManager/Source/Scene/ComposeScene/ComposeViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ComposeScene/ComposeViewController.swift
@@ -21,6 +21,7 @@ final class ComposeViewController: UIViewController, View {
     weak var coordinator: ComposeViewCoordinator?
     private let deleteEventSubject = PublishSubject<IndexPath?>()
     private let ocrEventSubject = PublishSubject<IndexPath?>()
+    private let retryEventSubject = PublishSubject<Void>()
     private var keyboardHandler: KeyboardHandler?
     private var ocrResultViewHeightConstraint: NSLayoutConstraint?
     
@@ -152,6 +153,10 @@ extension ComposeViewController {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        retryEventSubject.map { Reactor.Action.ocrRetry }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         registerButton.rx.tap
             .withUnretained(self)
             .map { (owner, _) in
@@ -236,10 +241,21 @@ extension ComposeViewController {
             }
             .disposed(by: disposeBag)
             
-        reactor.state.map { $0.composeError }
+        reactor.state.map { $0.registerError }
+            .observe(on: MainScheduler.instance)
             .compactMap { $0 }
             .bind { [weak self] error in
-                self?.coordinator?.presentAlert(error: error)
+                guard let self = self else { return }
+                self.coordinator?.presentAlert(error: error)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.ocrError }
+            .observe(on: MainScheduler.instance)
+            .compactMap { $0 }
+            .bind { [weak self] error in
+                guard let self = self else { return }
+                self.coordinator?.presentAlert(error: error, delegate: self)
             }
             .disposed(by: disposeBag)
     }
@@ -252,6 +268,13 @@ extension ComposeViewController {
             paymentType: infoView.payTypeSegmented.selectedSegmentIndex,
             memo: memoTextView.text
         )
+    }
+}
+
+// MARK: - Retry OCR Error Handling
+extension ComposeViewController: Retriable {
+    func retry() {
+        retryEventSubject.onNext(Void())
     }
 }
 

--- a/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/CalendarViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/CalendarScene/CalendarViewController.swift
@@ -102,7 +102,8 @@ extension CalendarViewController: UICollectionViewDelegate {
                     count: data.countOfExpense,
                     amount: data.amountOfExpense,
                     isToday: data.isToday,
-                    userDefaultEvent: self.reactor?.currencyRepository.saveEvent ?? BehaviorSubject<Int>(value: .zero)
+                    userDefaultEvent: self.reactor?
+                        .currencyRepository.saveEvent ?? BehaviorSubject<Int>(value: .zero)
                 )
             }
             .disposed(by: disposeBag)

--- a/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/ListScene/ListViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/ExpenseScene/ListScene/ListViewController.swift
@@ -30,7 +30,8 @@ final class ListViewController: UIViewController, View {
             
             cell.reactor = ListTableViewCellReactor(
                 expense: receipt,
-                userDefaultEvent: self.reactor?.currencyRepository.saveEvent ?? BehaviorSubject<Int>(value: .zero)
+                userDefaultEvent: self.reactor?
+                    .currencyRepository.saveEvent ?? BehaviorSubject<Int>(value: .zero)
             )
             
             return cell

--- a/ReceiptManager/ReceiptManager/Source/Service/StorageService.swift
+++ b/ReceiptManager/ReceiptManager/Source/Service/StorageService.swift
@@ -100,7 +100,7 @@ final class DefaultStorageService: StorageService {
                     observer.onCompleted()
                 } catch {
                     Crashlytics.crashlytics().record(error: error)
-                    observer.onError(StorageServiceError.entityUpdateError)
+                    observer.onError(StorageServiceError.entityDeleteError)
                 }
             }
             return Disposables.create()

--- a/ReceiptManager/ReceiptManager/Source/Utility/ConstantText.swift
+++ b/ReceiptManager/ReceiptManager/Source/Utility/ConstantText.swift
@@ -45,6 +45,7 @@ enum ConstantText {
     static let delete = "delete"
     
     static let cancle = "cancle"
+    static let retry = "retry"
     static let close = "close"
     static let complete = "complete"
     static let edit = "edit"


### PR DESCRIPTION
## 주요 변경 사항
1. OCR Error가 발생할 경우 재시도(복구)할 수 있도록 개선

## 과정
1. OCR Error가 발생할 경우 재시도(복구)할 수 있도록 개선
- 기존에는 OCR Error가 발생할 경우 확인만 가능했었습니다.
- 하지만 CoreData Error와 같이 OCRError는 복구가 가능한 오류라고 판단되어 재시도 기능을 추가하였습니다.
2. 추가 과정
- ComposeViewController 내부에 OCRError와 RegisterError를 기존에는 합쳐서 관리하였지만 재시도 기능을 위해 별도로 분리하였습니다.
- ocrError가 발생할 경우 delegate를 AlertViewController에 주입하여, delegate 메서드를 통해 retry 되도록 수정하였습니다.
- retry를 하려면 ocr이 실패한 이미지의 indexPath가 필요하기 때문에 ComposeViewReactor에서 별도로 ocrErrorIndexPath를 추가하였습니다.