### PR TITLE
[Version/2.0.1] MainThread Bug Fix

### DIFF
--- a/ReceiptManager/ReceiptManager/Source/Scene/AnalysisScene/Reactor/AnalysisViewReactor.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/AnalysisScene/Reactor/AnalysisViewReactor.swift
@@ -112,9 +112,10 @@ final class AnalysisViewReactor: Reactor {
             }
         
         let dateEvent = dateRepository.fetchActiveDate()
-            .flatMap { date in
-                return self.loadData(by: date).flatMap { models in
-                    return Observable.just(Mutation.updateAnalysis(self.analysisExpenses(datas: models)))
+            .withUnretained(self)
+            .flatMap { (owner, date) in
+                return owner.loadData(by: date).flatMap { models in
+                    return Observable.just(Mutation.updateAnalysis(owner.analysisExpenses(datas: models)))
                 }
             }
         

--- a/ReceiptManager/ReceiptManager/Source/Scene/DetailScene/DetailViewController.swift
+++ b/ReceiptManager/ReceiptManager/Source/Scene/DetailScene/DetailViewController.swift
@@ -185,6 +185,7 @@ extension DetailViewController: UICollectionViewDelegate {
             .disposed(by: disposeBag)
         
         reactor.state.map { $0.expense }
+            .observe(on: MainScheduler.instance)
             .withUnretained(self)
             .bind { (owner, item) in
                 owner.updateUI(item: item)
@@ -222,6 +223,7 @@ extension DetailViewController: UICollectionViewDelegate {
             .disposed(by: disposeBag)
         
         reactor.state.map { $0.deleteExpense }
+            .observe(on: MainScheduler.instance)
             .compactMap { $0 }
             .withUnretained(self)
             .bind { (owner, _) in
@@ -230,6 +232,7 @@ extension DetailViewController: UICollectionViewDelegate {
             .disposed(by: disposeBag)
         
         reactor.state.map { $0.dataError }
+            .observe(on: MainScheduler.instance)
             .compactMap { $0 }
             .bind { [weak self] error in
                 self?.coordinator?.presentAlert(error: error)


### PR DESCRIPTION
## 주요 변경 사항
1. DetailView에서 Delete 시 메인스레드 오류 발생 수정
2. DetailView에서 Delete Error 발생 시 메인스레드 오류 발생 수정
3. ListViewReactor, CalendarViewReactor, AnalysisViewReactor 내부 self 참조시 약한참조로 수정

## 과정
1. DetailViewController 내부 Reactor와 Bind 시, 다른 스레드 동작여지가 있는(Coredata) 부분에 메인스레드 이동 로직 추가하였습니다.
2. ListViewReactor, CalendarViewReactor, AnalysisViewReactor 내부 클로저에서 self 참조시 불필요한 RC 상승되지 않도록 withUnRetained처리 추가하였습니다.