### PR TITLE
[Version 2.1.0] Paste Button ToolBar에 추가

### DIFF
--- a/ReceiptManager/ReceiptManager/Source/Utility/ConstantImage.swift
+++ b/ReceiptManager/ReceiptManager/Source/Utility/ConstantImage.swift
@@ -50,4 +50,5 @@ enum ConstantImage {
     static let setting = "gear"
     
     static let checkMark = "checkmark"
+    static let pasteText = "doc.on.clipboard.fill"
 }

--- a/ReceiptManager/ReceiptManager/Source/Utility/Extension/UIViewController+Extension.swift
+++ b/ReceiptManager/ReceiptManager/Source/Utility/Extension/UIViewController+Extension.swift
@@ -40,6 +40,7 @@ extension UIViewController {
         toolbar.sizeToFit()
         
         let flexSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        
         let doneButton = UIBarButtonItem(
             image: UIImage(systemName: ConstantImage.keyboardDown),
             style: .done,
@@ -47,8 +48,16 @@ extension UIViewController {
             action: #selector(keyboardDone)
         )
         
+        let pasteButton = UIBarButtonItem(
+            image: UIImage(systemName: ConstantImage.pasteText),
+            style: .done,
+            target: self,
+            action: #selector(pasteText)
+        )
+        
         doneButton.tintColor = .label
-        toolbar.setItems([flexSpace, doneButton], animated: false)
+        pasteButton.tintColor = .label
+        toolbar.setItems([flexSpace, pasteButton, doneButton], animated: false)
         
         if let textView = textView as? UITextView {
             textView.inputAccessoryView = toolbar
@@ -59,5 +68,33 @@ extension UIViewController {
     
     @objc func keyboardDone() {
         view.endEditing(true)
+    }
+    
+    @objc func pasteText() {
+        if let clipboardText = UIPasteboard.general.string {
+            
+            if let textView = view.currentFirstResponder() as? UITextView {
+                textView.insertText(clipboardText)
+            } else if let textField = view.currentFirstResponder() as? UITextField {
+                textField.insertText(clipboardText)
+            }
+        }
+        
+        view.endEditing(true)
+    }
+}
+
+// Find Current Focus View
+extension UIView {
+    func currentFirstResponder() -> UIResponder? {
+        if isFirstResponder { return self }
+        
+        for view in subviews {
+            if let responder = view.currentFirstResponder() {
+                return responder
+            }
+        }
+        
+        return nil
     }
 }


### PR DESCRIPTION
### ## 주요 변경 사항
1. 키보드 툴바에 붙여넣기 버튼 추가 구현

## 과정
1. 기존의 키보드 툴바에 pasteButton 추가
2. ViewContoller와 View Extension하여 현재의 FirstResponder을 찾아서 해당 TextView 혹은 TextField에 Text Insert되도록 구현하였습니다.
```swift
// Find Current Focus View
extension UIView {
    func currentFirstResponder() -> UIResponder? {
        if isFirstResponder { return self }
        
        for view in subviews {
            if let responder = view.currentFirstResponder() {
                return responder
            }
        }
        
        return nil
    }
}
```